### PR TITLE
docs: Add Fix button to documentation pages

### DIFF
--- a/site/src/_layouts/section.hbs
+++ b/site/src/_layouts/section.hbs
@@ -1,17 +1,17 @@
 ---
 layout: default
 ---
+
 <div class="container component">
   <div class="row">
 
     <div class="col-sm-9 col-xs-12">
       <h1>
         {{title}}
-        {{#if component}}
-        <a class="btn btn-default" href="{{package.repository.url}}/blob/master/src/{{component}}">View source</a>
-        {{/if}}
       </h1>
       {{{body}}}
+
+      <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/{{{page.path}}}" target+"_blank">Submit a fix!</a></p>
 
       <nav class="visible-xs-block">
         <ul class="pager">

--- a/site/src/style/_base.scss
+++ b/site/src/style/_base.scss
@@ -21,6 +21,13 @@ h1 {
 	margin-bottom: 20px;
 }
 
+.edit-page-block {
+	padding: 1em;
+	margin: 2rem 0;
+	text-align: center;
+	background: darken($brand-offwhite, 5%);
+}
+
 footer {
 	background: $brand-background;
 	color: white;


### PR DESCRIPTION
for #111 

Was it something like this you had in mind? 
![sendafix](https://cloud.githubusercontent.com/assets/11503443/20676836/fcc27680-b588-11e6-8ed2-be48d66862ad.jpg)

the btn links to https://github.com/d3fc/d3fc/issues