### PR TITLE
feat: add use-device-pixel-ratio attribute

### DIFF
--- a/packages/d3fc-element/README.md
+++ b/packages/d3fc-element/README.md
@@ -108,8 +108,8 @@ Equivalent to invoking [*surface*.requestRedraw](#surface-requestRedraw) on all 
 
 The following custom DOM events are emitted by the elements -
 
-* `measure` - indicates that the rendering surface has been measured (only [&lt;d3fc-svg&gt;](#d3fc-svg)/[&lt;d3fc-canvas&gt;](#d3fc-canvas)). Typically the `measure` event is used to set the [range](https://github.com/d3/d3-scale#continuous_range) on scales or apply transforms.
-* `draw` - indicates that the rendering surface requires drawing. Typically the `draw` event is used to render components or perform any bespoke data-joins.
+* `measure` - indicates that the element has been measured. Typically the `measure` event is used to set the [range](https://github.com/d3/d3-scale#continuous_range) on scales or apply transforms.
+* `draw` - indicates that the element requires drawing. Typically the `draw` event is used to render components or perform any bespoke data-joins.
 
 The following properties are available under the `detail` property on the event (not available for [&lt;d3fc-group&gt;](#d3fc-group)) -
 

--- a/packages/d3fc-element/README.md
+++ b/packages/d3fc-element/README.md
@@ -73,6 +73,10 @@ Enqueues a redraw to occur on the next animation frame, only if there isn't alre
 
 It should be noted that `requestRedraw` is asynchronous. It does not directly invoke the draw event so any errors thrown in the event handler can not be caught.
 
+<a name="surface_useDevicePixelRatio" href="#surface_useDevicePixelRatio">#</a> *surface*.**useDevicePixelRatio**()
+
+Available as the property `useDevicePixelRatio` or the attribute `use-device-pixel-ratio`. Controls whether the surface dimensions are multiplied by the [`devicePixelDepth`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) if available.
+
 ### &lt;d3fc-group&gt;
 
 An element with no visual representation that is designed to group related rendering surfaces ([&lt;d3fc-svg&gt;](#d3fc-svg)/[&lt;d3fc-canvas&gt;](#d3fc-canvas)). Its core purpose is to multi-cast [*group*.requestRedraw](#group-requestRedraw) calls to descendant surfaces and to provide an aggregate draw event. It additionally provides helpers to allow [auto-resizing](#group-autoResize) of descendant surfaces in response to window `resize` events.

--- a/packages/d3fc-element/src/canvas.js
+++ b/packages/d3fc-element/src/canvas.js
@@ -1,3 +1,9 @@
 import element from './element';
 
-export default element(() => document.createElement('canvas'));
+export default element(
+    () => document.createElement('canvas'),
+    (node, { width, height }) => {
+        node.setAttribute('width', width);
+        node.setAttribute('height', height);
+    }
+);

--- a/packages/d3fc-element/src/css.js
+++ b/packages/d3fc-element/src/css.js
@@ -1,6 +1,6 @@
 // Adapted from https://github.com/substack/insert-css
 const css = `d3fc-canvas,d3fc-svg{position:relative;display:block}\
-d3fc-canvas>canvas,d3fc-svg>svg{position:absolute;top:0;right:0;left:0;bottom: 0}\
+d3fc-canvas>canvas,d3fc-svg>svg{position:absolute;height:100%;width:100%}\
 d3fc-svg>svg{overflow:visible}`;
 
 const styleElement = document.createElement('style');

--- a/packages/d3fc-element/src/element.js
+++ b/packages/d3fc-element/src/element.js
@@ -6,12 +6,66 @@ if (typeof HTMLElement !== 'function') {
     throw new Error('d3fc-element depends on Custom Elements (v1). Make sure that you load a polyfill in older browsers. See README.');
 }
 
-export default (createNode) => class extends HTMLElement {
+const addMeasureListener = (element) => {
+    if (element.__measureListener__ != null) {
+        return;
+    }
+    element.__measureListener__ = (event) => element.setMeasurements(event.detail);
+    element.addEventListener('measure', element.__measureListener__);
+};
+
+const removeMeasureListener = (element) => {
+    if (element.__measureListener__ == null) {
+        return;
+    }
+    element.removeEventListener('measure', element.__measureListener__);
+    element.__measureListener__ = null;
+};
+
+export default (createNode, applyMeasurements) => class extends HTMLElement {
+
+    static get observedAttributes() {
+        return ['use-device-pixel-ratio'];
+    }
+
+    attributeChangedCallback(name) {
+        switch (name) {
+        case 'use-device-pixel-ratio':
+            this.requestRedraw();
+            break;
+        }
+    }
 
     connectedCallback() {
         if (this.childNodes.length === 0) {
             this.appendChild(createNode());
         }
+        addMeasureListener(this);
+    }
+
+    disconnectedCallback() {
+        removeMeasureListener(this);
+    }
+
+    setMeasurements({ width, height }) {
+        const { childNodes: [node, ...other] } = this;
+        if (other.length > 0) {
+            throw new Error('A d3fc-svg/canvas element must only contain a single svg/canvas element.');
+        }
+        applyMeasurements(node, { width, height });
+    }
+
+    get useDevicePixelRatio() {
+        return this.hasAttribute('use-device-pixel-ratio') && this.getAttribute('use-device-pixel-ratio') !== 'false';
+    }
+
+    set useDevicePixelRatio(useDevicePixelRatio) {
+        if (useDevicePixelRatio && !this.useDevicePixelRatio) {
+            this.setAttribute('use-device-pixel-ratio', '');
+        } else if (!useDevicePixelRatio && this.useDevicePixelRatio) {
+            this.removeAttribute('use-device-pixel-ratio');
+        }
+        this.requestRedraw();
     }
 
     requestRedraw() {

--- a/packages/d3fc-element/src/redraw.js
+++ b/packages/d3fc-element/src/redraw.js
@@ -11,10 +11,11 @@ const measure = (element) => {
         return;
     }
     const { width: previousWidth, height: previousHeight } = data.get(element);
-    const width = element.clientWidth;
-    const height = element.clientHeight;
+    const pixelRatio = (element.useDevicePixelRatio && global.devicePixelRatio != null) ? global.devicePixelRatio : 1;
+    const width = element.clientWidth * pixelRatio;
+    const height = element.clientHeight * pixelRatio;
     const resized = width !== previousWidth || height !== previousHeight;
-    data.set(element, { width, height, resized });
+    data.set(element, { pixelRatio, width, height, resized });
 };
 
 if (typeof CustomEvent !== 'function') {
@@ -26,9 +27,6 @@ const resize = (element) => {
         return;
     }
     const detail = data.get(element);
-    const node = element.childNodes[0];
-    node.setAttribute('width', detail.width);
-    node.setAttribute('height', detail.height);
     const event = new CustomEvent('measure', { detail });
     element.dispatchEvent(event);
 };

--- a/packages/d3fc-element/src/redraw.js
+++ b/packages/d3fc-element/src/redraw.js
@@ -7,9 +7,6 @@ const find = (element) => element.tagName === 'D3FC-GROUP'
   : [element];
 
 const measure = (element) => {
-    if (element.tagName === 'D3FC-GROUP') {
-        return;
-    }
     const { width: previousWidth, height: previousHeight } = data.get(element);
     const pixelRatio = (element.useDevicePixelRatio && global.devicePixelRatio != null) ? global.devicePixelRatio : 1;
     const width = element.clientWidth * pixelRatio;
@@ -23,9 +20,6 @@ if (typeof CustomEvent !== 'function') {
 }
 
 const resize = (element) => {
-    if (element.tagName === 'D3FC-GROUP') {
-        return;
-    }
     const detail = data.get(element);
     const event = new CustomEvent('measure', { detail });
     element.dispatchEvent(event);

--- a/packages/d3fc-element/src/svg.js
+++ b/packages/d3fc-element/src/svg.js
@@ -1,3 +1,8 @@
 import element from './element';
 
-export default element(() => document.createElementNS('http://www.w3.org/2000/svg', 'svg'));
+export default element(
+    () => document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+    (node, { width, height }) => {
+        node.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    }
+);


### PR DESCRIPTION
The surface will now throw if it detects elements have been added to it, ensure elements are added as descendants of the svg.

Fixes #1126.
Fixes #1125.