### PR TITLE
fix: sub-transition interval redraws hide nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-register": "^6.26.0",
     "command-line-args": "^3.0.1",
     "cross-spawn": "^5.0.1",
+    "d3": "^5.7.0",
     "eol": "^0.4.0",
     "eslint": "^3.1.0",
     "eslint-config-defaults": "^9.0.0",

--- a/packages/d3fc-annotation/test/bundleSpec.js
+++ b/packages/d3fc-annotation/test/bundleSpec.js
@@ -8,18 +8,9 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-array/build/d3-array.js',
-                './node_modules/d3-collection/build/d3-collection.js',
-                './node_modules/d3-color/build/d3-color.js',
-                './node_modules/d3-format/build/d3-format.js',
-                './node_modules/d3-interpolate/build/d3-interpolate.js',
-                './node_modules/d3-time/build/d3-time.js',
-                './node_modules/d3-time-format/build/d3-time-format.js',
-                './node_modules/d3-scale/build/d3-scale.js',
-                './node_modules/d3-selection/dist/d3-selection.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-data-join/build/d3fc-data-join.js',
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
-                './node_modules/d3-path/build/d3-path.js',
                 './node_modules/@d3fc/d3fc-series/build/d3fc-series.js',
                 './node_modules/@d3fc/d3fc-shape/build/d3fc-shape.js',
                 './build/d3fc-annotation.js'

--- a/packages/d3fc-axis/test/bundleSpec.js
+++ b/packages/d3fc-axis/test/bundleSpec.js
@@ -8,17 +8,7 @@ describe('bundle', () => {
                 error: fail
             }),
             scripts: [
-                // transitive dependencies
-                './node_modules/d3-array/build/d3-array.js',
-                './node_modules/d3-collection/build/d3-collection.js',
-                './node_modules/d3-color/build/d3-color.js',
-                './node_modules/d3-format/build/d3-format.js',
-                './node_modules/d3-interpolate/build/d3-interpolate.js',
-                './node_modules/d3-time-format/build/d3-time-format.js',
-                // direct dependencies
-                './node_modules/d3-shape/build/d3-shape.js',
-                './node_modules/d3-scale/build/d3-scale.js',
-                './node_modules/d3-selection/dist/d3-selection.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-data-join/build/d3fc-data-join.js',
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-axis.js'

--- a/packages/d3fc-chart/test/bundleSpec.js
+++ b/packages/d3fc-chart/test/bundleSpec.js
@@ -8,17 +8,7 @@ describe('bundle', () => {
                 error: fail
             }),
             scripts: [
-                // transitive dependencies
-                './node_modules/d3-array/build/d3-array.js',
-                './node_modules/d3-collection/build/d3-collection.js',
-                './node_modules/d3-color/build/d3-color.js',
-                './node_modules/d3-format/build/d3-format.js',
-                './node_modules/d3-interpolate/build/d3-interpolate.js',
-                './node_modules/d3-time-format/build/d3-time-format.js',
-                // direct dependencies
-                './node_modules/d3-shape/build/d3-shape.js',
-                './node_modules/d3-scale/build/d3-scale.js',
-                './node_modules/d3-selection/dist/d3-selection.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-data-join/build/d3fc-data-join.js',
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './node_modules/@d3fc/d3fc-series/build/d3fc-series.js',

--- a/packages/d3fc-data-join/src/dataJoin.js
+++ b/packages/d3fc-data-join/src/dataJoin.js
@@ -47,16 +47,14 @@ export default (element, className) => {
         // if transitions are enabled apply a default fade in/out transition
         const transition = implicitTransition || explicitTransition;
         if (transition) {
-            update = update.transition(transition);
-            enter.style('opacity', effectivelyZero)
-                .transition(transition)
+            update = update.transition(transition)
                 .style('opacity', 1);
+            enter.style('opacity', effectivelyZero);
             exit = exit.transition(transition)
-                .style('opacity', effectivelyZero)
-                .remove();
-        } else {
-            exit.remove();
+                .style('opacity', effectivelyZero);
         }
+
+        exit.remove();
 
         update.enter = () => enter;
         update.exit = () => exit;

--- a/packages/d3fc-data-join/test/bundleSpec.js
+++ b/packages/d3fc-data-join/test/bundleSpec.js
@@ -8,7 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                require.resolve('d3-selection'),
+                require.resolve('d3/dist/d3.js'),
                 require.resolve('..')
             ],
             done: (_, win) => {
@@ -26,13 +26,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                require.resolve('d3-selection'),
-                require.resolve('d3-color'),
-                require.resolve('d3-dispatch'),
-                require.resolve('d3-ease'),
-                require.resolve('d3-interpolate'),
-                require.resolve('d3-timer'),
-                require.resolve('d3-transition'),
+                require.resolve('d3/dist/d3.js'),
                 require.resolve('..')
             ],
             done: (_, win) => {

--- a/packages/d3fc-discontinuous-scale/test/bundleSpec.js
+++ b/packages/d3fc-discontinuous-scale/test/bundleSpec.js
@@ -8,16 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                // transitive dependencies
-                './node_modules/d3-array/build/d3-array.js',
-                './node_modules/d3-collection/build/d3-collection.js',
-                './node_modules/d3-color/build/d3-color.js',
-                './node_modules/d3-format/build/d3-format.js',
-                './node_modules/d3-interpolate/build/d3-interpolate.js',
-                './node_modules/d3-time-format/build/d3-time-format.js',
-                // direct dependencies
-                './node_modules/d3-scale/build/d3-scale.js',
-                './node_modules/d3-time/build/d3-time.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-discontinuous-scale.js'
             ],

--- a/packages/d3fc-extent/test/bundleSpec.js
+++ b/packages/d3fc-extent/test/bundleSpec.js
@@ -8,7 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-array/build/d3-array.js',
+                require.resolve('d3/dist/d3.js'),
                 './build/d3fc-extent.js'
             ],
             done: (_, win) => {

--- a/packages/d3fc-financial-feed/test/bundleSpec.js
+++ b/packages/d3fc-financial-feed/test/bundleSpec.js
@@ -8,8 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                // direct dependencies
-                './node_modules/d3-fetch/dist/d3-fetch.js',
+                require.resolve('d3/dist/d3.js'),
                 './build/d3fc-financial-feed.js'
             ],
             done: (_, win) => {

--- a/packages/d3fc-label-layout/test/bundleSpec.js
+++ b/packages/d3fc-label-layout/test/bundleSpec.js
@@ -9,7 +9,7 @@ describe('bundle', () => {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3/build/d3.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-data-join/build/d3fc-data-join.js',
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-label-layout.js'

--- a/packages/d3fc-pointer/test/bundleSpec.js
+++ b/packages/d3fc-pointer/test/bundleSpec.js
@@ -8,8 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-dispatch/build/d3-dispatch.js',
-                './node_modules/d3-selection/dist/d3-selection.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-pointer.js'
             ],

--- a/packages/d3fc-random-data/test/bundleSpec.js
+++ b/packages/d3fc-random-data/test/bundleSpec.js
@@ -8,8 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-random/build/d3-random.js',
-                './node_modules/d3-time/build/d3-time.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-random-data.js'
             ],

--- a/packages/d3fc-sample/test/bundleSpec.js
+++ b/packages/d3fc-sample/test/bundleSpec.js
@@ -8,7 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-array/build/d3-array.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-sample.js'
             ],

--- a/packages/d3fc-series/test/bundleSpec.js
+++ b/packages/d3fc-series/test/bundleSpec.js
@@ -8,7 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3/build/d3.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-shape/build/d3fc-shape.js',
                 './node_modules/@d3fc/d3fc-data-join/build/d3fc-data-join.js',
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',

--- a/packages/d3fc-shape/test/bundleSpec.js
+++ b/packages/d3fc-shape/test/bundleSpec.js
@@ -8,7 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-path/build/d3-path.js',
+                require.resolve('d3/dist/d3.js'),
                 './build/d3fc-shape.js'
             ],
             done: (_, win) => {

--- a/packages/d3fc-technical-indicator/test/bundleSpec.js
+++ b/packages/d3fc-technical-indicator/test/bundleSpec.js
@@ -8,7 +8,7 @@ describe('bundle', function() {
                 error: fail
             }),
             scripts: [
-                './node_modules/d3-array/build/d3-array.js',
+                require.resolve('d3/dist/d3.js'),
                 './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-technical-indicator.js'
             ],


### PR DESCRIPTION
Fixes #1164

I've copied the logic from [d3's axis](https://github.com/d3/d3-axis/blob/master/src/axis.js#L78)
