### PR TITLE
docs: fixed example where the chart was hidden

### DIFF
--- a/packages/d3fc-site/src/introduction/building-a-chart-complete.css
+++ b/packages/d3fc-site/src/introduction/building-a-chart-complete.css
@@ -3,9 +3,8 @@
   stroke-width: 0;
 }
 
-.plot-area {
-  background-color: white;
-  overflow: hidden;
+.y-label {
+  white-space: nowrap;
 }
 
 d3fc-svg svg {


### PR DESCRIPTION
The chart example set a background colour for the plot-area. However, we now have two plot areas, one canvas, one SVG. The canvas has a higher z-order, so this styling was resulting in the chart being hidden!