### PR TITLE
docs: remove site reference to D3 version

### DIFF
--- a/packages/d3fc-site/src/index.html
+++ b/packages/d3fc-site/src/index.html
@@ -19,7 +19,7 @@ externals:
     <div class="row">
       <div class="col-sm-4 col-xs-12">
         <img alt="d3fc" src="{{baseurl}}/images/logo.svg" />
-        <p>Components for building interactive charts with D3(v4)</p>
+        <p>Components for building interactive charts with D3</p>
       </div>
     </div>
   </div>
@@ -52,7 +52,7 @@ externals:
       <div class="col-sm-4">
         <img alt="module" src="{{baseurl}}/images/modular.png" />
         <h3>Modular</h3>
-        <p>d3fc is a collection of modules that are designed to make it easier to build charts with D3(v4), extending its vocabulary from SVG paths,
+        <p>d3fc is a collection of modules that are designed to make it easier to build charts with D3, extending its vocabulary from SVG paths,
           rectangles and groups, into series, annotation and chart. You can use the modules independently, or you can use them together
           as part of the default bundle.</p>
       </div>

--- a/packages/d3fc-site/src/introduction/getting-started.md
+++ b/packages/d3fc-site/src/introduction/getting-started.md
@@ -13,7 +13,7 @@ externals:
 d3fc and its dependencies are available via npm or the unpkg CDN. The d3fc project is composed of a number of separate
 packages, detailed in the {{{ hyperlink 'annotation-api.html' title='API documentation' }}}. Each of these packages can be installed via npm and used independently, or if you you can install the entire d3fc bundle, which includes all of the separate packages.
 
-This packaging style mirrors the way that D3(v4) is distributed.
+This packaging style mirrors the way that D3 is distributed.
 
 ### Installing the bundle with npm
 


### PR DESCRIPTION
I have removed the reference to the D3 version that exists on the site.

Fixes [#1196](https://github.com/d3fc/d3fc/issues/1196)