### PR TITLE
docs: correct cross links between packages

### DIFF
--- a/packages/d3fc-brush/README.md
+++ b/packages/d3fc-brush/README.md
@@ -19,7 +19,7 @@ npm install @d3fc/d3fc-brush
 The d3fc-brush component adapts the [d3-brush](https://github.com/d3/d3-brush), to achieve the following:
 
  1. The d3fc-brush is data-driven, with the location of the brush determined by the data supplied via a data join. This makes it easier to create charts that are responsive (i.e, support re-sizing), integrate with other interactive components such as zoom, and create chart rendering logic that is idempotent.
- 2. The d3fc-brush exposes `xScale` and `yScale` properties for integration with the [multi series](https://github.com/d3fc/d3fc#multi-series) component and [cartesian chart](https://github.com/d3fc/d3fc) component. As a result the extent of the brush is automatically set based on the range of each axis.
+ 2. The d3fc-brush exposes `xScale` and `yScale` properties for integration with the [multi series](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-series#multi-series) component and [cartesian chart](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-chart#cartesian) component. As a result the extent of the brush is automatically set based on the range of each axis.
  3. The d3fc-brush selection (which defines the brushed range), is represented as a percentage, whereas d3-brush uses pixels. The use of a percentage selection makes it easier to resize a brushed chart.
  4. The brush events expose utility functions for computing the axis domain based on the current selection, making it easier to handle brush events and update the chart.
 

--- a/packages/d3fc-chart/README.md
+++ b/packages/d3fc-chart/README.md
@@ -16,7 +16,7 @@ npm install @d3fc/d3fc-chart
 
 ### General API
 
-d3fc provides a number of components / building blocks that make it easier to build bespoke d3 charts, using SVG and canvas. If you just need a simple Cartesian chart, this package is a good starting point, providing a simple component that is itself built using components from the other d3fc packages ([d3fc-element](https://github.com/d3fc/d3fc), [d3fc-data-join](https://github.com/d3fc/d3fc), [d3fc-axis](https://github.com/d3fc/d3fc), [d3fc-series](https://github.com/d3fc/d3fc), etc ...).
+d3fc provides a number of components / building blocks that make it easier to build bespoke d3 charts, using SVG and canvas. If you just need a simple Cartesian chart, this package is a good starting point, providing a simple component that is itself built using components from the other d3fc packages ([d3fc-element](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-element#d3fc-element), [d3fc-data-join](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-data-join#d3fc-data-join), [d3fc-axis](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-axis#d3fc-axis), [d3fc-series](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-series#d3fc-series), etc ...).
 
 Given the following div:
 
@@ -271,4 +271,4 @@ The Cartesian chart exposes the scale properties with either an `x` or `y` prefi
 <a name="cartesian_yDecorate" href="#cartesian_yDecorate">#</a> *cartesian*.**yDecorate**(...)  
 ...
 
-The Cartesian chart exposes the [d3fc-axis](https://github.com/d3fc/d3fc) *ticks*, *tickSize*, *tickValue*, *tickFormat* and *decorate* properties with either an `x` or `y` prefix.
+The Cartesian chart exposes the [d3fc-axis](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-axis#d3fc-axis) *ticks*, *tickSize*, *tickValue*, *tickFormat* and *decorate* properties with either an `x` or `y` prefix.

--- a/packages/d3fc-series/README.md
+++ b/packages/d3fc-series/README.md
@@ -826,7 +826,7 @@ Rendering a grouped series requires a nested array of data, the default format e
 ]
 ```
 
-The `fc.group` component from the [d3fc-group](https://github.com/d3fc/d3fc) package gives an easy way to construct this data from CSV / TSV.
+The `fc.group` component from the [d3fc-group](https://github.com/d3fc/d3fc/tree/master/packages/d3fc-group#d3fc-group) package gives an easy way to construct this data from CSV / TSV.
 
 With the data in the correct format, the series is rendered just like the other series types:
 


### PR DESCRIPTION
Cross links between packages will now link to the corresponding GitHub page.

Fixes [#1191](https://github.com/d3fc/d3fc/issues/1191)