### PR TITLE
Fixed display of bubble-sort transition example

### DIFF
--- a/introduction/building-a-chart.html
+++ b/introduction/building-a-chart.html
@@ -928,7 +928,7 @@ d3.selectAll('.complete-chart')
 <p>If you want to make a more complex chart, for example, one with multiple axes, a good starting point is to look at the source code for the Cartesian chart component to see how that has been constructed form other d3fc components.</p>
 
 
-    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/introduction/building-a-chart.md" target+"_blank">Submit a fix!</a></p>
+    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/edit/gh-pages/introduction/building-a-chart.md" target+"_blank">Submit a fix!</a></p>
   </div>
 
   <nav class="col-sm-3 hidden-xs nav-container">

--- a/introduction/component-design.html
+++ b/introduction/component-design.html
@@ -73,7 +73,7 @@
 <p>Components do not cache the results of any calculations nor attempt any other performance optimisations (beyond <a href="http://bost.ocks.org/mike/selection/">D3&#39;s update pattern</a>). For example, every call will recalculate everything from the supplied data.</p>
 
 
-    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/introduction/component-design.md" target+"_blank">Submit a fix!</a></p>
+    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/edit/gh-pages/introduction/component-design.md" target+"_blank">Submit a fix!</a></p>
   </div>
 
   <nav class="col-sm-3 hidden-xs nav-container">

--- a/introduction/decorate-pattern.html
+++ b/introduction/decorate-pattern.html
@@ -286,7 +286,7 @@ container.append('g')
 </script>
 
 
-    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/introduction/decorate-pattern.md" target+"_blank">Submit a fix!</a></p>
+    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/edit/gh-pages/introduction/decorate-pattern.md" target+"_blank">Submit a fix!</a></p>
   </div>
 
   <nav class="col-sm-3 hidden-xs nav-container">

--- a/introduction/getting-started.html
+++ b/introduction/getting-started.html
@@ -59,7 +59,7 @@
     </h1>
     <h2 id="grabbing-the-code">Grabbing the code</h2>
 <p>d3fc and its dependencies are available via npm or the unpkg CDN. The d3fc project is composed of a number of separate
-packages, detailed in the <a href="/api/annotation-api.html">API documentation</a>. Each of these packages can be installed via npm and used independently, or if you you can install the entire d3fc bundle, which includes all of the separate packages.</p>
+packages, detailed in the <a href="/api/annotation-api.html">API documentation</a>. Each of these packages can be installed via npm and used independently, or if you prefer you can install the entire d3fc bundle, which includes all of the separate packages.</p>
 <p>This packaging style mirrors the way that D3 is distributed.</p>
 <h3 id="installing-the-bundle-with-npm">Installing the bundle with npm</h3>
 <p>d3fc depends on D3, you can install both the d3fc bundle and D3 via npm as follows:</p>

--- a/introduction/getting-started.html
+++ b/introduction/getting-started.html
@@ -155,7 +155,7 @@ d3.select('#chart')
 <p>The next step is to follow the more in-depth tutorial on <a href="/introduction/building-a-chart.html">building a chart</a>.</p>
 
 
-    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/introduction/getting-started.md" target+"_blank">Submit a fix!</a></p>
+    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/edit/gh-pages/introduction/getting-started.md" target+"_blank">Submit a fix!</a></p>
   </div>
 
   <nav class="col-sm-3 hidden-xs nav-container">

--- a/introduction/transitions.html
+++ b/introduction/transitions.html
@@ -76,10 +76,6 @@
   stroke-width: 0;
 }
 
-.plot-area {
-  background-color: white;
-}
-
 d3fc-svg svg {
   overflow: visible !important;
 }

--- a/introduction/transitions.html
+++ b/introduction/transitions.html
@@ -190,7 +190,7 @@ render();
 </code></pre>
 
 
-    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/introduction/transitions.md" target+"_blank">Submit a fix!</a></p>
+    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/edit/gh-pages/introduction/transitions.html" target+"_blank">Submit a fix!</a></p>
   </div>
 
   <nav class="col-sm-3 hidden-xs nav-container">


### PR DESCRIPTION
The bars weren't visible. Now that d3fc outputs a `canvas` element as well as `svg`, the white background on `.plot-area` meant that the `svg` element was hidden.

Also a couple of other minor edits.