### PR TITLE
Fixed display of bubble-sort transition example

### DIFF
--- a/packages/d3fc-site/src/_layouts/section.hbs
+++ b/packages/d3fc-site/src/_layouts/section.hbs
@@ -9,7 +9,7 @@ layout: default
     </h1>
     {{{body}}}
 
-    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/site/src/{{{page.path}}}" target+"_blank">Submit a fix!</a></p>
+    <p class="edit-page-block">Found a problem in this page? <a href="https://github.com/d3fc/d3fc/tree/master/packages/d3fc-site/src/{{{page.path}}}" target+"_blank">Submit a fix!</a></p>
   </div>
 
   <nav class="col-sm-3 hidden-xs nav-container">

--- a/packages/d3fc-site/src/introduction/getting-started.md
+++ b/packages/d3fc-site/src/introduction/getting-started.md
@@ -11,7 +11,7 @@ externals:
 ## Grabbing the code
 
 d3fc and its dependencies are available via npm or the unpkg CDN. The d3fc project is composed of a number of separate
-packages, detailed in the {{{ hyperlink 'annotation-api.html' title='API documentation' }}}. Each of these packages can be installed via npm and used independently, or if you you can install the entire d3fc bundle, which includes all of the separate packages.
+packages, detailed in the {{{ hyperlink 'annotation-api.html' title='API documentation' }}}. Each of these packages can be installed via npm and used independently, or if you prefer you can install the entire d3fc bundle, which includes all of the separate packages.
 
 This packaging style mirrors the way that D3 is distributed.
 

--- a/packages/d3fc-site/src/introduction/transitions.css
+++ b/packages/d3fc-site/src/introduction/transitions.css
@@ -3,10 +3,6 @@
   stroke-width: 0;
 }
 
-.plot-area {
-  background-color: white;
-}
-
 d3fc-svg svg {
   overflow: visible !important;
 }


### PR DESCRIPTION
The bars weren't visible. Now that d3fc outputs a canvas element as well as svg, the white background on .plot-area meant that the svg element was hidden.

Also a couple of other minor edits.