### PR TITLE
Fixed issue with horizontal seriesGrouped offset in wrong direction

### DIFF
--- a/packages/d3fc-series/examples/grouped.html
+++ b/packages/d3fc-series/examples/grouped.html
@@ -19,7 +19,9 @@
     <svg id="grouped-svg-autobandwidth-bandscale"></svg>
     <svg id="grouped-svg-autobandwidth-linearscale"></svg>
     <svg id="grouped-svg-variable-bandwidth"></svg>
+    <svg id="grouped-svg-horizontal"></svg>
     <canvas id="grouped-canvas"  width="500" height="250"></canvas>
+    <canvas id="grouped-canvas-horizontal"  width="500" height="250"></canvas>
     <script src="grouped.js"></script>
 </body>
 </html>

--- a/packages/d3fc-series/examples/grouped.js
+++ b/packages/d3fc-series/examples/grouped.js
@@ -122,6 +122,44 @@ d3.select('#grouped-svg-variable-bandwidth')
     .datum(series)
     .call(groupedBar);
 
+// Show a horizontal grouped bar
+var yHorizontal = d3.scaleBand()
+    .domain(data.map(function(d) { return d.State; }))
+    .paddingInner(0.2)
+    .paddingOuter(0.1)
+    .rangeRound([0, height]);
+
+var xHorizontalExtent = fc.extentLinear()
+    .accessors([
+        function(a) {
+            return a.map(function(d) { return d[1]; });
+        }
+    ])
+    .include([0]);
+
+var xHorizontal = d3.scaleLinear()
+    .domain(xHorizontalExtent(series))
+    .range([0, width]);
+
+var groupedHorizontal = fc.seriesSvgGrouped(groupedSeries)
+    .orient('horizontal')
+    .xScale(xHorizontal)
+    .yScale(yHorizontal)
+    .align('left')
+    .crossValue(function(d) { return d[0]; })
+    .mainValue(function(d) { return d[1]; })
+    .decorate(function(sel, data, index) {
+        sel.enter()
+            .select('path')
+            .attr('fill', function() { return color(index); });
+    });
+
+d3.select('#grouped-svg-horizontal')
+    .attr('width', width)
+    .attr('height', height)
+    .datum(series)
+    .call(fc.autoBandwidth(groupedHorizontal));
+
 var canvas = d3.select('#grouped-canvas').node();
 canvas.width = width;
 canvas.height = height;
@@ -142,3 +180,22 @@ var groupedCanvasBar = fc.autoBandwidth(fc.seriesCanvasGrouped(groupedCanvasSeri
     });
 
 groupedCanvasBar(series);
+
+var canvasHorizontal = d3.select('#grouped-canvas-horizontal').node();
+canvasHorizontal.width = width;
+canvasHorizontal.height = height;
+
+// create the horizontal grouped series
+var groupedCanvasBarHorizontal = fc.autoBandwidth(fc.seriesCanvasGrouped(fc.seriesCanvasBar()))
+    .orient('horizontal')
+    .xScale(xHorizontal)
+    .yScale(yHorizontal)
+    .align('left')
+    .crossValue(function(d) { return d[0]; })
+    .mainValue(function(d) { return d[1]; })
+    .context(canvasHorizontal.getContext('2d'))
+    .decorate(function(ctx, data, index) {
+        ctx.fillStyle = color(index);
+    });
+
+groupedCanvasBarHorizontal(series);

--- a/packages/d3fc-series/src/canvas/grouped.js
+++ b/packages/d3fc-series/src/canvas/grouped.js
@@ -10,13 +10,22 @@ export default function(series) {
         data.forEach((seriesData, index) => {
 
             // create a composite scale that applies the required offset
+            const isVertical = series.orient() !== 'horizontal';
             const compositeScale = (d, i) => {
                 const offset = base.offsetScaleForDatum(data, d, i);
-                return base.xScale()(d) +
+                const baseScale = isVertical ? base.xScale() : base.yScale();
+                return baseScale(d) +
                   offset(index) +
                   offset.bandwidth() / 2;
             };
-            series.xScale(compositeScale);
+
+            if (isVertical) {
+                series.xScale(compositeScale);
+                series.yScale(base.yScale());
+            } else {
+                series.yScale(compositeScale);
+                series.xScale(base.xScale());
+            }
 
             // if the sub-series has a bandwidth, set this from the offset scale
             if (series.bandwidth) {
@@ -32,8 +41,8 @@ export default function(series) {
         });
     };
 
-    rebindAll(grouped, series, exclude('decorate', 'xScale'));
-    rebindAll(grouped, base, exclude('configureOffsetScale', 'configureOffset'));
+    rebindAll(grouped, series, exclude('decorate', 'xScale', 'yScale'));
+    rebindAll(grouped, base, exclude('offsetScaleForDatum'));
 
     return grouped;
 }

--- a/packages/d3fc-series/src/groupedBase.js
+++ b/packages/d3fc-series/src/groupedBase.js
@@ -15,7 +15,8 @@ export default (series) => {
 
     const grouped = createBase({
         decorate: () => {},
-        xScale: scaleLinear()
+        xScale: scaleLinear(),
+        yScale: scaleLinear()
     });
 
     // the bandwidth for the grouped series can be a function of datum / index. As a result

--- a/packages/d3fc-series/src/svg/grouped.js
+++ b/packages/d3fc-series/src/svg/grouped.js
@@ -29,13 +29,22 @@ export default (series) => {
                     const container = select(group[index]);
 
                     // create a composite scale that applies the required offset
+                    const isVertical = series.orient() !== 'horizontal';
                     const compositeScale = (d, i) => {
                         const offset = base.offsetScaleForDatum(data, d, i);
-                        return base.xScale()(d) +
+                        const baseScale = isVertical ? base.xScale() : base.yScale();
+                        return baseScale(d) +
                           offset(index) +
                           offset.bandwidth() / 2;
                     };
-                    series.xScale(compositeScale);
+
+                    if (isVertical) {
+                        series.xScale(compositeScale);
+                        series.yScale(base.yScale());
+                    } else {
+                        series.yScale(compositeScale);
+                        series.xScale(base.xScale());
+                    }
 
                     // if the sub-series has a bandwidth, set this from the offset scale
                     if (series.bandwidth) {
@@ -53,7 +62,7 @@ export default (series) => {
         });
     };
 
-    rebindAll(grouped, series, exclude('decorate', 'xScale'));
+    rebindAll(grouped, series, exclude('decorate', 'xScale', 'yScale'));
     rebindAll(grouped, base, exclude('offsetScaleForDatum'));
 
     return grouped;


### PR DESCRIPTION
When the seriesSvgGrouped is used with a seriesSvgBar in "horizontal" orientation (i.e. bars instead of columns), it still offsets the individual bars in the X direction, so they overlap each other, instead of in the Y direction.