### PR TITLE
Added multi-level grouping ability to chart axis labelling

### DIFF
--- a/packages/d3fc-axis/src/axis.js
+++ b/packages/d3fc-axis/src/axis.js
@@ -79,10 +79,7 @@ const axis = (orient, scale) => {
     const groupLineOffset = (d, arr, direction = 1) => {
         if (!tickGrouping) return arr;
 
-        let bandwidth = scale.bandwidth ? scale.bandwidth() : 0;
-        if (scale.padding()) {
-            bandwidth /= scale.padding();
-        }
+        let bandwidth = scale.step ? scale.step() : 0;
         if (d.domain) bandwidth *= d.domain.length;
 
         return arr.map(d => [d[0] + direction * bandwidth / 2, d[1]]);

--- a/packages/d3fc-chart/examples/multi-ordinal.html
+++ b/packages/d3fc-chart/examples/multi-ordinal.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.js"></script>
+    <script src="../node_modules/d3/build/d3.js"></script>
+    <script src="../../d3fc-data-join/build/d3fc-data-join.js"></script>
+    <script src="../../d3fc-rebind/build/d3fc-rebind.js"></script>
+    <script src="../../d3fc-axis/build/d3fc-axis.js"></script>
+    <script src="../../d3fc-extent/build/d3fc-extent.js"></script>
+    <script src="../../d3fc-element/build/d3fc-element.js"></script>
+    <script src="../../d3fc-series/build/d3fc-series.js"></script>
+    <script src="../../d3fc-shape/build/d3fc-shape.js"></script>
+    <script src="../../d3fc-annotation/build/d3fc-annotation.js"></script>
+    <script src="../build/d3fc-chart.js"></script>
+</head>
+<body>
+    <div id="multiOrdinal" style="width: 1000px; height: 450px"></div>
+    <div id="multiOrdinalHorizontal" style="width: 1000px; height: 450px"></div>
+    <script src="multi-ordinal.js"></script>
+</body>
+</html>

--- a/packages/d3fc-chart/examples/multi-ordinal.js
+++ b/packages/d3fc-chart/examples/multi-ordinal.js
@@ -1,0 +1,101 @@
+var data = [
+  {
+    'period': 'Old|2017|Q1',
+    'sales': 1
+  },
+  {
+    'period': 'Old|2017|Q2',
+    'sales': 1.5332793661950717
+  },
+  {
+    'period': 'Old|2017|Q3',
+    'sales': 2.0486834288742597
+  },
+  {
+    'period': 'Old|2017|Q4',
+    'sales': 2.556310832331535
+  },
+  {
+    'period': 'New|2018|Q1',
+    'sales': 3.029535759511747
+  },
+  {
+    'period': 'New|2018|Q2',
+    'sales': 3.507418002703505
+  },
+  {
+    'period': 'New|2018|Q3',
+    'sales': 4.02130992651795
+  },
+  {
+    'period': 'New|2018|Q4',
+    'sales': 4.482485234741706
+  },
+  {
+    'period': 'New|2019|Q1',
+    'sales': 4.957935275183866
+  },
+  {
+    'period': 'New|2019|Q2',
+    'sales': 5.427273488256043
+  },
+  {
+    'period': 'New|2019|Q3',
+    'sales': 5.943007604008045
+  }
+];
+
+var yExtent = fc.extentLinear()
+  .accessors([d => d.sales])
+  .include([0]);
+
+var bar = fc.autoBandwidth(fc.seriesSvgBar())
+  .crossValue(d => d.period)
+  .mainValue(d => d.sales)
+  .align("left");
+
+var chart = fc.chartSvgCartesian(
+      d3.scaleBand().padding(0.5),
+      d3.scaleLinear()
+  )
+  .xLabel('Quarter')
+  .xTickPadding(5)
+  .xTickSizeInner(15)
+  .xAxisSize(45)
+  .xTickGrouping(tick => tick.split('|'))
+  .xTickSizeOuter(5)
+  .yLabel('Value')
+  .yOrient('left')
+  .yDomain(yExtent(data))
+  .xDomain(data.map(d => d.period))
+  .plotArea(bar);
+
+d3.select('#multiOrdinal')
+  .datum(data)
+  .call(chart);
+
+var barHorizontal = fc.autoBandwidth(fc.seriesSvgBar())
+  .crossValue(d => d.period)
+  .mainValue(d => d.sales)
+  .align("left")
+  .orient("horizontal");
+
+var chartHorizontal = fc.chartSvgCartesian(
+    d3.scaleLinear(),
+    d3.scaleBand().padding(0.5)
+)
+.yLabel('Quarter')
+.yTickPadding(5)
+.yTickSizeInner(25)
+.yAxisSize(90)
+.yTickGrouping(tick => tick.split('|'))
+.yTickSizeOuter(5)
+.xLabel('Value')
+.yOrient('left')
+.xDomain(yExtent(data))
+.yDomain(data.map(d => d.period))
+.plotArea(barHorizontal);
+
+d3.select('#multiOrdinalHorizontal')
+.datum(data)
+.call(chartHorizontal);

--- a/packages/d3fc-chart/examples/multi-ordinal.js
+++ b/packages/d3fc-chart/examples/multi-ordinal.js
@@ -1,101 +1,101 @@
 var data = [
-  {
-    'period': 'Old|2017|Q1',
-    'sales': 1
-  },
-  {
-    'period': 'Old|2017|Q2',
-    'sales': 1.5332793661950717
-  },
-  {
-    'period': 'Old|2017|Q3',
-    'sales': 2.0486834288742597
-  },
-  {
-    'period': 'Old|2017|Q4',
-    'sales': 2.556310832331535
-  },
-  {
-    'period': 'New|2018|Q1',
-    'sales': 3.029535759511747
-  },
-  {
-    'period': 'New|2018|Q2',
-    'sales': 3.507418002703505
-  },
-  {
-    'period': 'New|2018|Q3',
-    'sales': 4.02130992651795
-  },
-  {
-    'period': 'New|2018|Q4',
-    'sales': 4.482485234741706
-  },
-  {
-    'period': 'New|2019|Q1',
-    'sales': 4.957935275183866
-  },
-  {
-    'period': 'New|2019|Q2',
-    'sales': 5.427273488256043
-  },
-  {
-    'period': 'New|2019|Q3',
-    'sales': 5.943007604008045
-  }
+    {
+        'period': 'Old|2017|Q1',
+        'sales': 1
+    },
+    {
+        'period': 'Old|2017|Q2',
+        'sales': 1.5332793661950717
+    },
+    {
+        'period': 'Old|2017|Q3',
+        'sales': 2.0486834288742597
+    },
+    {
+        'period': 'Old|2017|Q4',
+        'sales': 2.556310832331535
+    },
+    {
+        'period': 'New|2018|Q1',
+        'sales': 3.029535759511747
+    },
+    {
+        'period': 'New|2018|Q2',
+        'sales': 3.507418002703505
+    },
+    {
+        'period': 'New|2018|Q3',
+        'sales': 4.02130992651795
+    },
+    {
+        'period': 'New|2018|Q4',
+        'sales': 4.482485234741706
+    },
+    {
+        'period': 'New|2019|Q1',
+        'sales': 4.957935275183866
+    },
+    {
+        'period': 'New|2019|Q2',
+        'sales': 5.427273488256043
+    },
+    {
+        'period': 'New|2019|Q3',
+        'sales': 5.943007604008045
+    }
 ];
 
 var yExtent = fc.extentLinear()
-  .accessors([d => d.sales])
-  .include([0]);
+    .accessors([d => d.sales])
+    .include([0]);
 
 var bar = fc.autoBandwidth(fc.seriesSvgBar())
-  .crossValue(d => d.period)
-  .mainValue(d => d.sales)
-  .align("left");
+    .crossValue(d => d.period)
+    .mainValue(d => d.sales)
+    .align('left');
 
 var chart = fc.chartSvgCartesian(
-      d3.scaleBand().padding(0.5),
-      d3.scaleLinear()
-  )
-  .xLabel('Quarter')
-  .xTickPadding(5)
-  .xTickSizeInner(15)
-  .xAxisSize(45)
-  .xTickGrouping(tick => tick.split('|'))
-  .xTickSizeOuter(5)
-  .yLabel('Value')
-  .yOrient('left')
-  .yDomain(yExtent(data))
-  .xDomain(data.map(d => d.period))
-  .plotArea(bar);
+    d3.scaleBand().padding(0.5),
+    d3.scaleLinear()
+)
+    .xLabel('Quarter')
+    .xTickPadding(5)
+    .xTickSizeInner(15)
+    .xAxisSize(45)
+    .xTickGrouping(tick => tick.split('|'))
+    .xTickSizeOuter(5)
+    .yLabel('Value')
+    .yOrient('left')
+    .yDomain(yExtent(data))
+    .xDomain(data.map(d => d.period))
+    .plotArea(bar);
 
 d3.select('#multiOrdinal')
-  .datum(data)
-  .call(chart);
+    .datum(data)
+    .call(chart);
 
 var barHorizontal = fc.autoBandwidth(fc.seriesSvgBar())
-  .crossValue(d => d.period)
-  .mainValue(d => d.sales)
-  .align("left")
-  .orient("horizontal");
+    .crossValue(d => d.period)
+    .mainValue(d => d.sales)
+    .align('left')
+    .orient('horizontal');
 
 var chartHorizontal = fc.chartSvgCartesian(
     d3.scaleLinear(),
     d3.scaleBand().padding(0.5)
 )
-.yLabel('Quarter')
-.yTickPadding(5)
-.yTickSizeInner(25)
-.yAxisSize(90)
-.yTickGrouping(tick => tick.split('|'))
-.yTickSizeOuter(5)
-.xLabel('Value')
-.yOrient('left')
-.xDomain(yExtent(data))
-.yDomain(data.map(d => d.period))
-.plotArea(barHorizontal);
+    .yLabel('Quarter')
+    .yTickPadding(5)
+    .yTickSizeInner(25)
+    .yAxisSize(90)
+    .yTickGrouping(tick => tick.split('|'))
+    .yTickSizeOuter(5)
+    .xLabel('Value')
+    .yOrient('left')
+    .xDomain(yExtent(data))
+    .yDomain(data.map(d => d.period))
+    .plotArea(barHorizontal);
 
 d3.select('#multiOrdinalHorizontal')
-.datum(data)
-.call(chartHorizontal);
+    .datum(data)
+    .call(chartHorizontal);

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -14,13 +14,15 @@ export default (xScale = scaleIdentity(), yScale = scaleIdentity()) => {
 
     let xLabel = functor('');
     let yLabel = functor('');
+    let xAxisSize = 0;
+    let yAxisSize = 0;
     let yOrient = functor('right');
     let xOrient = functor('bottom');
     let canvasPlotArea = seriesCanvasMulti();
     let svgPlotArea = seriesSvgMulti();
-    let xAxisStore = store('tickFormat', 'ticks', 'tickArguments', 'tickSize', 'tickSizeInner', 'tickSizeOuter', 'tickValues', 'tickPadding');
+    let xAxisStore = store('tickFormat', 'ticks', 'tickArguments', 'tickSize', 'tickSizeInner', 'tickSizeOuter', 'tickValues', 'tickPadding', 'tickGrouping');
     let xDecorate = () => { };
-    let yAxisStore = store('tickFormat', 'ticks', 'tickArguments', 'tickSize', 'tickSizeInner', 'tickSizeOuter', 'tickValues', 'tickPadding');
+    let yAxisStore = store('tickFormat', 'ticks', 'tickArguments', 'tickSize', 'tickSizeInner', 'tickSizeOuter', 'tickValues', 'tickPadding', 'tickGrouping');
     let yDecorate = () => { };
     let decorate = () => { };
 
@@ -61,6 +63,7 @@ export default (xScale = scaleIdentity(), yScale = scaleIdentity()) => {
 
             xAxisDataJoin(container, [xOrient(data)])
                 .attr('class', d => `x-axis ${d}-axis`)
+                .style('height', xAxisSize ? `${xAxisSize}px` : '')
                 .on('measure', (d, i, nodes) => {
                     const { width, height } = event.detail;
                     if (d === 'top') {
@@ -80,6 +83,7 @@ export default (xScale = scaleIdentity(), yScale = scaleIdentity()) => {
 
             yAxisDataJoin(container, [yOrient(data)])
                 .attr('class', d => `y-axis ${d}-axis`)
+                .style('width', yAxisSize ? `${yAxisSize}px` : '')
                 .on('measure', (d, i, nodes) => {
                     const { width, height } = event.detail;
                     if (d === 'left') {
@@ -172,6 +176,20 @@ export default (xScale = scaleIdentity(), yScale = scaleIdentity()) => {
             return yLabel;
         }
         yLabel = functor(args[0]);
+        return cartesian;
+    };
+    cartesian.xAxisSize = (...args) => {
+        if (!args.length) {
+            return xAxisSize;
+        }
+        xAxisSize = args[0];
+        return cartesian;
+    };
+    cartesian.yAxisSize = (...args) => {
+        if (!args.length) {
+            return yAxisSize;
+        }
+        yAxisSize = args[0];
         return cartesian;
     };
     cartesian.canvasPlotArea = (...args) => {


### PR DESCRIPTION
After chatting with Colin on Friday, about whether it was feasible to replace the Cartesian chart's axis with a custom or extended version of the axis component, he said he'd be interested in whether we could improve the capabilities of the existing axis component...

Extended cartesian chart and axis so that:
* x/y axis size can be specified (allows for extra room for rotated axis or for multi-levels as below)
* axis has a "tickGrouping" function that allows you to group the axis labelling into multiple levels

![image](https://user-images.githubusercontent.com/8255295/52949924-95dd2880-3375-11e9-8674-1e79bdebd881.png)
