### PR TITLE
feat: Dynamically insert css into head or shadow-dom if missing

### DIFF
--- a/packages/d3fc-chart/examples/shadow-dom.html
+++ b/packages/d3fc-chart/examples/shadow-dom.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.js"></script>
+    <script src="../node_modules/d3/build/d3.js"></script>
+    <script src="../../d3fc-data-join/build/d3fc-data-join.js"></script>
+    <script src="../../d3fc-rebind/build/d3fc-rebind.js"></script>
+    <script src="../../d3fc-axis/build/d3fc-axis.js"></script>
+    <script src="../../d3fc-extent/build/d3fc-extent.js"></script>
+    <script src="../../d3fc-element/build/d3fc-element.js"></script>
+    <script src="../../d3fc-series/build/d3fc-series.js"></script>
+    <script src="../../d3fc-shape/build/d3fc-shape.js"></script>
+    <script src="../../d3fc-annotation/build/d3fc-annotation.js"></script>
+    <script src="../build/d3fc-chart.js"></script>
+</head>
+<body>
+    <script src="shadow-dom.js"></script>
+    <div style="width: 500px; height: 250px">
+        <shadow-example></shadow-example>
+    </div>
+</body>
+</html>

--- a/packages/d3fc-chart/examples/shadow-dom.js
+++ b/packages/d3fc-chart/examples/shadow-dom.js
@@ -1,0 +1,99 @@
+var data = [
+  {
+    'month': 'Jan',
+    'sales': 1
+  },
+  {
+    'month': 'Feb',
+    'sales': 1.5332793661950717
+  },
+  {
+    'month': 'Mar',
+    'sales': 2.0486834288742597
+  },
+  {
+    'month': 'Apr',
+    'sales': 2.556310832331535
+  },
+  {
+    'month': 'May',
+    'sales': 3.029535759511747
+  },
+  {
+    'month': 'Jun',
+    'sales': 3.507418002703505
+  },
+  {
+    'month': 'Jul',
+    'sales': 4.02130992651795
+  },
+  {
+    'month': 'Aug',
+    'sales': 4.482485234741706
+  },
+  {
+    'month': 'Sep',
+    'sales': 4.957935275183866
+  },
+  {
+    'month': 'Oct',
+    'sales': 5.427273488256043
+  },
+  {
+    'month': 'Nov',
+    'sales': 5.943007604008045
+  },
+  {
+    'month': 'Dec',
+    'sales': 6.454464059891373
+  }
+];
+
+const cssStyle = `
+.chart {
+  height: 100%;
+}
+`;
+
+class ShadowExample extends HTMLElement {
+  connectedCallback() {
+    var shadow = this.attachShadow({ mode: 'open' });
+
+    var wrapper = document.createElement('div');
+    wrapper.setAttribute('class', 'chart');
+    shadow.appendChild(wrapper);
+
+    var style = document.createElement('style');
+    style.textContent = cssStyle;
+    shadow.appendChild(style);
+    
+    this.renderChart(wrapper);
+  }
+
+  renderChart(wrapper) {
+    var yExtent = fc.extentLinear()
+      .accessors([d => d.sales])
+      .include([0]);
+
+    var bar = fc.seriesSvgBar()
+      .crossValue(d => d.month)
+      .mainValue(d => d.sales);
+
+    var chart = fc.chartCartesian(
+      d3.scalePoint().padding(0.5),
+      d3.scaleLinear()
+    )
+      .xLabel('Month')
+      .yLabel('Value')
+      .yOrient('left')
+      .yDomain(yExtent(data))
+      .xDomain(data.map(d => d.month))
+      .svgPlotArea(bar);
+
+    d3.select(wrapper)
+      .datum(data)
+      .call(chart);
+  }
+}
+
+customElements.define('shadow-example', ShadowExample);

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -5,7 +5,7 @@ import { axisBottom, axisRight, axisLeft, axisTop } from '@d3fc/d3fc-axis';
 import { dataJoin } from '@d3fc/d3fc-data-join';
 import { rebindAll, exclude, prefix } from '@d3fc/d3fc-rebind';
 import store from './store';
-import './css';
+import { css } from './css';
 
 const functor = (v) =>
     typeof v === 'function' ? v : () => v;
@@ -46,6 +46,9 @@ export default (xScale = scaleIdentity(), yScale = scaleIdentity()) => {
 
             container.enter()
                 .attr('auto-resize', '')
+                .each((d, i, nodes) => {
+                    nodes[i].applyCss(css, 'd3fc-chart-css');
+                })
                 .html(
                     '<d3fc-svg class="plot-area"></d3fc-svg>' +
                     '<d3fc-canvas class="plot-area"></d3fc-canvas>'

--- a/packages/d3fc-chart/src/css.js
+++ b/packages/d3fc-chart/src/css.js
@@ -1,5 +1,5 @@
 // Adapted from https://github.com/substack/insert-css
-const css = `d3fc-group.cartesian-chart{width:100%;height:100%;overflow:hidden;display:grid;display:-ms-grid;grid-template-columns:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);-ms-grid-columns:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);grid-template-rows:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);-ms-grid-rows:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);}
+export const css = `d3fc-group.cartesian-chart{width:100%;height:100%;overflow:hidden;display:grid;display:-ms-grid;grid-template-columns:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);-ms-grid-columns:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);grid-template-rows:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);-ms-grid-rows:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);}
 d3fc-group.cartesian-chart>.top-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;-ms-grid-row:1;-ms-grid-row:1;}
 d3fc-group.cartesian-chart>.top-axis{height:2em;grid-column:3;-ms-grid-column:3;grid-row:2;-ms-grid-row:2;}
 d3fc-group.cartesian-chart>.left-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:1;-ms-grid-column:1;grid-row:3;-ms-grid-row:3;}
@@ -9,15 +9,3 @@ d3fc-group.cartesian-chart>.right-axis{width:3em;grid-column:4;-ms-grid-column:4
 d3fc-group.cartesian-chart>.right-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:5;-ms-grid-column:5;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.bottom-axis{height:2em;grid-column:3;-ms-grid-column:3;grid-row:4;-ms-grid-row:4;}
 d3fc-group.cartesian-chart>.bottom-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;grid-row:5;-ms-grid-row:5;}`;
-
-const styleElement = document.createElement('style');
-styleElement.setAttribute('type', 'text/css');
-
-document.querySelector('head')
-  .appendChild(styleElement);
-
-if (styleElement.styleSheet) {
-    styleElement.styleSheet.cssText += css;
-} else {
-    styleElement.textContent += css;
-}

--- a/packages/d3fc-element/index.js
+++ b/packages/d3fc-element/index.js
@@ -2,7 +2,6 @@
 import Canvas from './src/canvas';
 import Group from './src/group';
 import Svg from './src/svg';
-import './src/css';
 
 if (typeof customElements !== 'object' || typeof customElements.define !== 'function') {
     throw new Error('d3fc-element depends on Custom Elements (v1). Make sure that you load a polyfill in older browsers. See README.');

--- a/packages/d3fc-element/src/css.js
+++ b/packages/d3fc-element/src/css.js
@@ -1,16 +1,22 @@
 // Adapted from https://github.com/substack/insert-css
-const css = `d3fc-canvas,d3fc-svg{position:relative;display:block}\
+export const css = `d3fc-canvas,d3fc-svg{position:relative;display:block}\
 d3fc-canvas>canvas,d3fc-svg>svg{position:absolute;height:100%;width:100%}\
 d3fc-svg>svg{overflow:visible}`;
 
-const styleElement = document.createElement('style');
-styleElement.setAttribute('type', 'text/css');
+export const insertCss = (node, css, id) => {
+    const root = node.getRootNode();
+    const head = root.querySelector('head') || root;
 
-document.querySelector('head')
-  .appendChild(styleElement);
+    if (!head.querySelector(`#${id}`)) {
+        var styleElement = document.createElement('style');
+        styleElement.setAttribute('type', 'text/css');
+        styleElement.setAttribute('id', id);
+        if (styleElement.styleSheet) {
+            styleElement.styleSheet.cssText += css;
+        } else {
+            styleElement.textContent += css;
+        }
 
-if (styleElement.styleSheet) {
-    styleElement.styleSheet.cssText += css;
-} else {
-    styleElement.textContent += css;
-}
+        head.appendChild(styleElement);
+    }
+};

--- a/packages/d3fc-element/src/element.js
+++ b/packages/d3fc-element/src/element.js
@@ -1,6 +1,7 @@
 /* eslint-env browser */
 
 import requestRedraw from './requestRedraw';
+import {css as elementCss, insertCss} from './css';
 
 if (typeof HTMLElement !== 'function') {
     throw new Error('d3fc-element depends on Custom Elements (v1). Make sure that you load a polyfill in older browsers. See README.');
@@ -38,6 +39,7 @@ export default (createNode, applyMeasurements) => class extends HTMLElement {
 
     connectedCallback() {
         if (this.childNodes.length === 0) {
+            insertCss(this, elementCss, 'd3fc-element-css');
             this.appendChild(createNode());
         }
         addMeasureListener(this);
@@ -70,5 +72,9 @@ export default (createNode, applyMeasurements) => class extends HTMLElement {
 
     requestRedraw() {
         requestRedraw(this);
+    }
+
+    applyCss(css, id) {
+        insertCss(this, css, id);
     }
 };

--- a/packages/d3fc-element/src/group.js
+++ b/packages/d3fc-element/src/group.js
@@ -1,6 +1,7 @@
 /* eslint-env browser */
 
 import requestRedraw from './requestRedraw';
+import {insertCss} from './css';
 
 const updateAutoResize = (element) => {
     if (element.autoResize) {
@@ -62,5 +63,9 @@ export default class extends HTMLElement {
             updateAutoResize(this);
             break;
         }
+    }
+
+    applyCss(css, id) {
+        insertCss(this, css, id);
     }
 };


### PR DESCRIPTION
`d3fc-element` and `d3fc-chart` dynamically load their required css into either the document head, or else the root of the shadow dom, rather than always loading the css info the document head as a one-off.

The style element is created with an id, and we check if it exists before adding it again.

Added an example of a chart hosted in a shadow-dom.