### PR TITLE
feat: [For Preliminary Review - Do Not Merge] added new padding strategy component to extent package

### DIFF
--- a/packages/d3fc-extent/examples/.eslintrc.json
+++ b/packages/d3fc-extent/examples/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "defaults/configurations/eslint",
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "fc": true,
+    "d3": true
+  }
+}

--- a/packages/d3fc-extent/examples/hardLimitZeroPadding.html
+++ b/packages/d3fc-extent/examples/hardLimitZeroPadding.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.js"></script>
+    <script src="../node_modules/d3/build/d3.js"></script>
+    <script src="../../d3fc-data-join/build/d3fc-data-join.js"></script>
+    <script src="../../d3fc-rebind/build/d3fc-rebind.js"></script>
+    <script src="../../d3fc-axis/build/d3fc-axis.js"></script>
+    <script src="../../d3fc-extent/build/d3fc-extent.js"></script>
+    <script src="../../d3fc-element/build/d3fc-element.js"></script>
+    <script src="../../d3fc-series/build/d3fc-series.js"></script>
+    <script src="../../d3fc-annotation/build/d3fc-annotation.js"></script>
+    <script src="../../d3fc-chart/build/d3fc-chart.js"></script>
+    <script src="../build/d3fc-extent.js"></script>
+    <style>
+    path.area {
+        fill: #99ff99;
+        fill-opacity: 0.5;
+    }
+    path.line {
+        stroke: #60c;
+    }
+    .annotation-gridline line {
+        stroke: #ddd;
+    }
+    </style>
+</head>
+<body>
+    <h1>Charts where all data is positive</h1>
+    <div id="chartyMcChartFace_defaultPadding" style="width: 500px; height: 250px"></div>
+    <div id="chartyMcChartFace_hardLimitZeroPadding" style="width: 500px; height: 250px"></div>
+    <h1>Charts where all data is negative</h1>
+    <div id="chartyMcChartFace_defaultPadding_negative" style="width: 500px; height: 250px"></div>
+    <div id="chartyMcChartFace_hardLimitZeroPadding_negative" style="width: 500px; height: 250px"></div>
+    <script src="hardLimitZeroPadding.js"></script>
+    <script src="hardLimitZeroPaddingNegative.js"></script>
+</body>
+</html>

--- a/packages/d3fc-extent/examples/hardLimitZeroPadding.js
+++ b/packages/d3fc-extent/examples/hardLimitZeroPadding.js
@@ -1,0 +1,82 @@
+const data = [
+    {
+        date: '2012-05-01',
+        close: 58.13
+    },
+    {
+        date: '2012-04-19',
+        close: 345.44
+    },
+    {
+        date: '2012-04-11',
+        close: 626.2
+    },
+    {
+        date: '2012-03-26',
+        close: 606.98
+    }
+];
+
+// use d3fc-extent to compute the domain for each axis
+let yExtentDefault = fc.extentLinear()
+    .accessors([d => d.close])
+    .pad([200, 200])
+    .padUnit('domain');
+
+let gridlines = fc.annotationSvgGridline();
+let line = fc.seriesSvgLine()
+    .crossValue(d => d.date)
+    .mainValue(d => d.close);
+
+let multi = fc.seriesSvgMulti()
+    .series([gridlines, line]);
+
+let chart = fc.chartSvgCartesian(d3.scaleBand(), d3.scaleLinear())
+    .xLabel('date')
+    .yLabel('Cap')
+    .chartLabel('Market Data (See how the y axis overflows 0 into negative)')
+    .yOrient('left')
+    .yDomain(yExtentDefault(data))
+    .xDomain(data.map(d => d.date))
+    .plotArea(multi);
+
+// use d3fc-extent to compute the domain for each axis
+let yExtentZeroLimit = fc.extentLinear()
+    .accessors([d => d.close])
+    .paddingStrategy(fc.hardLimitZeroPadding()
+        .pad([200, 200])
+        .padUnit('domain')
+    );
+
+chart.decorate(selection => {
+    selection
+        .select('.chart-label')
+        .style('margin-bottom', '2em');
+});
+
+// render
+d3.select('#chartyMcChartFace_defaultPadding')
+    .datum(data)
+    .call(chart);
+
+// Illustrate the difference using hardLimitZero padding Strategy
+
+let zeroLimitChart = fc.chartSvgCartesian(d3.scaleBand(), d3.scaleLinear())
+    .xLabel('date')
+    .yLabel('Cap')
+    .chartLabel('Market Data With Hard Limit Zero (Configured padding ignored where it would cause an overflow into negative)')
+    .yOrient('left')
+    .yDomain(yExtentZeroLimit(data))
+    .xDomain(data.map(d => d.date))
+    .plotArea(multi);
+
+zeroLimitChart.decorate(selection => {
+    selection
+        .select('.chart-label')
+        .style('margin-bottom', '2em');
+});
+
+// render
+d3.select('#chartyMcChartFace_hardLimitZeroPadding')
+    .datum(data)
+    .call(zeroLimitChart);

--- a/packages/d3fc-extent/examples/hardLimitZeroPaddingNegative.js
+++ b/packages/d3fc-extent/examples/hardLimitZeroPaddingNegative.js
@@ -1,0 +1,82 @@
+const dataNeg = [
+    {
+        date: '2012-05-01',
+        close: -58.13
+    },
+    {
+        date: '2012-04-19',
+        close: -345.44
+    },
+    {
+        date: '2012-04-11',
+        close: -626.2
+    },
+    {
+        date: '2012-03-26',
+        close: -606.98
+    }
+];
+
+// use d3fc-extent to compute the domain for each axis
+let yExtentDefaultNeg = fc.extentLinear()
+    .accessors([d => d.close])
+    .pad([200, 200])
+    .padUnit('domain');
+
+let gridlinesNeg = fc.annotationSvgGridline();
+let lineNeg = fc.seriesSvgLine()
+    .crossValue(d => d.date)
+    .mainValue(d => d.close);
+
+let multiNeg = fc.seriesSvgMulti()
+    .series([gridlinesNeg, lineNeg]);
+
+let chartNeg = fc.chartSvgCartesian(d3.scaleBand(), d3.scaleLinear())
+    .xLabel('date')
+    .yLabel('Cap')
+    .chartLabel('Market Data (See how the y axis overflows 0 into positive)')
+    .yOrient('left')
+    .yDomain(yExtentDefaultNeg(dataNeg))
+    .xDomain(dataNeg.map(d => d.date))
+    .plotArea(multiNeg);
+
+// use d3fc-extent to compute the domain for each axis
+let yExtentZeroLimitNeg = fc.extentLinear()
+    .accessors([d => d.close])
+    .paddingStrategy(fc.hardLimitZeroPadding()
+        .pad([200, 200])
+        .padUnit('domain')
+    );
+
+chartNeg.decorate(selection => {
+    selection
+        .select('.chart-label')
+        .style('margin-bottom', '2em');
+});
+
+// render
+d3.select('#chartyMcChartFace_defaultPadding_negative')
+    .datum(dataNeg)
+    .call(chartNeg);
+
+// Illustrate the difference using hardLimitZero padding Strategy
+
+let zeroLimitChartNeg = fc.chartSvgCartesian(d3.scaleBand(), d3.scaleLinear())
+    .xLabel('date')
+    .yLabel('Cap')
+    .chartLabel('Market Data With Hard Limit Zero (Configured padding ignored where it would cause an overflow into positive)')
+    .yOrient('left')
+    .yDomain(yExtentZeroLimitNeg(dataNeg))
+    .xDomain(dataNeg.map(d => d.date))
+    .plotArea(multiNeg);
+
+zeroLimitChartNeg.decorate(selection => {
+    selection
+        .select('.chart-label')
+        .style('margin-bottom', '2em');
+});
+
+// render
+d3.select('#chartyMcChartFace_hardLimitZeroPadding_negative')
+    .datum(dataNeg)
+    .call(zeroLimitChartNeg);

--- a/packages/d3fc-extent/index.js
+++ b/packages/d3fc-extent/index.js
@@ -1,3 +1,5 @@
 export { default as extentLinear } from './src/linear';
 export { default as extentTime } from './src/time';
 export { default as extentDate } from './src/date';
+export { defaultPadding } from './src/padding/default';
+export { hardLimitZeroPadding } from './src/padding/hardLimitZero';

--- a/packages/d3fc-extent/package.json
+++ b/packages/d3fc-extent/package.json
@@ -24,10 +24,13 @@
   },
   "devDependencies": {
     "@d3fc/d3fc-scripts": "^2.0.4",
-    "ms": "^1.0.0"
+    "ms": "^1.0.0",
+    "babel-polyfill": "^6.13.0",
+    "d3": "^4.2.5"
   },
   "dependencies": {
-    "d3-array": "^1.0.0"
+    "d3-array": "^1.0.0",
+    "@d3fc/d3fc-rebind": "^5.0.6"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/d3fc-extent/src/linear.js
+++ b/packages/d3fc-extent/src/linear.js
@@ -1,10 +1,10 @@
 import { min, max } from 'd3-array';
+import { defaultPadding } from './padding/default';
 
 export default function() {
 
     let accessors = [ d => d ];
-    let pad = [0, 0];
-    let padUnit = 'percent';
+    let paddingStrategy = defaultPadding();
     let symmetricalAbout = null;
     let include = [];
 
@@ -35,23 +35,7 @@ export default function() {
             extent[1] = symmetricalAbout + halfRange;
         }
 
-        switch (padUnit) {
-        case 'domain': {
-            extent[0] -= pad[0];
-            extent[1] += pad[1];
-            break;
-        }
-        case 'percent': {
-            const delta = extent[1] - extent[0];
-            extent[0] -= pad[0] * delta;
-            extent[1] += pad[1] * delta;
-            break;
-        }
-        default:
-            throw new Error(`Unknown padUnit: ${padUnit}`);
-        }
-
-        return extent;
+        return paddingStrategy(extent);
     };
 
     instance.accessors = (...args) => {
@@ -62,19 +46,27 @@ export default function() {
         return instance;
     };
 
-    instance.pad = (...args) => {
-        if (!args.length) {
-            return pad;
+    instance.pad = function() {
+        if (!arguments.length) {
+            return paddingStrategy.pad;
         }
-        pad = args[0];
+        paddingStrategy.pad(arguments.length <= 0 ? undefined : arguments[0]);
         return instance;
     };
 
-    instance.padUnit = (...args) => {
-        if (!args.length) {
-            return padUnit;
+    instance.padUnit = function() {
+        if (!arguments.length) {
+            return paddingStrategy.padUnit;
         }
-        padUnit = args[0];
+        paddingStrategy.padUnit(arguments.length <= 0 ? undefined : arguments[0]);
+        return instance;
+    };
+
+    instance.paddingStrategy = function() {
+        if (!arguments.length) {
+            return paddingStrategy;
+        }
+        paddingStrategy = arguments.length <= 0 ? undefined : arguments[0];
         return instance;
     };
 

--- a/packages/d3fc-extent/src/padding/default.js
+++ b/packages/d3fc-extent/src/padding/default.js
@@ -1,0 +1,41 @@
+export const defaultPadding = () => {
+    let pad = [0, 0];
+    let padUnit = 'percent';
+
+    const padding = extent => {
+        switch (padUnit) {
+        case 'domain': {
+            extent[0] -= pad[0];
+            extent[1] += pad[1];
+            break;
+        }
+        case 'percent': {
+            let delta = extent[1] - extent[0];
+            extent[0] -= pad[0] * delta;
+            extent[1] += pad[1] * delta;
+            break;
+        }
+        default:
+            throw new Error('Unknown padUnit: ' + padUnit);
+        }
+        return extent;
+    };
+
+    padding.pad = function() {
+        if (!arguments.length) {
+            return pad;
+        }
+        pad = arguments.length <= 0 ? undefined : arguments[0];
+        return padding;
+    };
+
+    padding.padUnit = function() {
+        if (!arguments.length) {
+            return padUnit;
+        }
+        padUnit = arguments.length <= 0 ? undefined : arguments[0];
+        return padding;
+    };
+
+    return padding;
+};

--- a/packages/d3fc-extent/src/padding/hardLimitZero.js
+++ b/packages/d3fc-extent/src/padding/hardLimitZero.js
@@ -1,0 +1,36 @@
+import { defaultPadding } from './default';
+import { rebindAll } from '@d3fc/d3fc-rebind';
+
+export const hardLimitZeroPadding = () => {
+    const _defaultPadding = defaultPadding();
+
+    const padding = extent => {
+        let pad = _defaultPadding.pad();
+        let padUnit = _defaultPadding.padUnit();
+
+        let delta = 1;
+        switch (padUnit) {
+        case 'domain': {
+            break;
+        }
+        case 'percent': {
+            delta = extent[1] - extent[0];
+            break;
+        }
+        default:
+            throw new Error('Unknown padUnit: ' + padUnit);
+        }
+
+        let paddedLowerExtent = extent[0] - pad[0] * delta;
+        let paddedUpperExtent = extent[1] + pad[1] * delta;
+
+        // If datapoints are exclusively negative or exclusively positive hard limit extent to 0.
+        extent[0] = extent[0] >= 0 && paddedLowerExtent < 0 ? 0 : paddedLowerExtent;
+        extent[1] = extent[1] <= 0 && paddedUpperExtent > 0 ? 0 : paddedUpperExtent;
+        return extent;
+    };
+
+    rebindAll(padding, _defaultPadding);
+
+    return padding;
+};

--- a/packages/d3fc-extent/src/time.js
+++ b/packages/d3fc-extent/src/time.js
@@ -1,10 +1,10 @@
 import { default as linearExtent } from './linear';
+import { defaultPadding } from './padding/default';
 
 export default function() {
 
     let accessors = [];
-    let pad = [0, 0];
-    let padUnit = 'percent';
+    let paddingStrategy = defaultPadding();
     let symmetricalAbout = null;
     let include = [];
 
@@ -19,8 +19,9 @@ export default function() {
         });
 
         extent.accessors(adaptedAccessors)
-          .pad(pad)
-          .padUnit(padUnit)
+          .pad(paddingStrategy.pad)
+          .padUnit(paddingStrategy.padUnit)
+          .paddingStrategy(paddingStrategy)
           .symmetricalAbout(symmetricalAbout != null ? symmetricalAbout.valueOf() : null)
           .include(include.map(date => date.valueOf()));
 
@@ -36,19 +37,27 @@ export default function() {
         return instance;
     };
 
-    instance.pad = (...args) => {
-        if (!args.length) {
-            return pad;
+    instance.pad = function() {
+        if (!arguments.length) {
+            return paddingStrategy.pad;
         }
-        pad = args[0];
+        paddingStrategy.pad(arguments.length <= 0 ? undefined : arguments[0]);
         return instance;
     };
 
-    instance.padUnit = (...args) => {
-        if (!args.length) {
-            return padUnit;
+    instance.padUnit = function() {
+        if (!arguments.length) {
+            return paddingStrategy.padUnit;
         }
-        padUnit = args[0];
+        paddingStrategy.padUnit(arguments.length <= 0 ? undefined : arguments[0]);
+        return instance;
+    };
+
+    instance.paddingStrategy = function() {
+        if (!arguments.length) {
+            return paddingStrategy;
+        }
+        paddingStrategy = arguments.length <= 0 ? undefined : arguments[0];
         return instance;
     };
 

--- a/packages/d3fc-extent/test/bundleSpec.js
+++ b/packages/d3fc-extent/test/bundleSpec.js
@@ -9,6 +9,7 @@ describe('bundle', function() {
             }),
             scripts: [
                 require.resolve('d3/dist/d3.js'),
+                './node_modules/@d3fc/d3fc-rebind/build/d3fc-rebind.js',
                 './build/d3fc-extent.js'
             ],
             done: (_, win) => {

--- a/packages/d3fc-extent/test/deafultPaddingSpec.js
+++ b/packages/d3fc-extent/test/deafultPaddingSpec.js
@@ -1,0 +1,33 @@
+import linearExtent from '../src/linear';
+import { defaultPadding } from '../src/padding/default';
+
+describe('linear', () => {
+    const obj = (val) => ({ high: val + 5, low: val - 5 });
+
+    it('should support increasing the range with domain padding', function() {
+        var data = [obj(5), obj(15)];
+
+        var extents = linearExtent()
+            .accessors([d => d.high])
+            .paddingStrategy(
+                defaultPadding()
+                    .padUnit('domain')
+                    .pad([5, 10])
+            )(data);
+        expect(extents).toEqual([5, 30]);
+    });
+
+    it('should support decreasing the range with domain padding', function() {
+        var data = [obj(5), obj(15)];
+
+        var extents = linearExtent()
+            .accessors([d => d.high])
+            .paddingStrategy(
+                defaultPadding()
+                    .padUnit('domain')
+                    .pad([-5, -2])
+            )(data);
+        expect(extents).toEqual([15, 18]);
+    });
+
+});

--- a/packages/d3fc-extent/test/hardLimitZeroSpec.js
+++ b/packages/d3fc-extent/test/hardLimitZeroSpec.js
@@ -1,0 +1,54 @@
+import linearExtent from '../src/linear';
+import { hardLimitZeroPadding } from '../src/padding/hardLimitZero';
+
+describe('linear', () => {
+    const obj = (val) => ({ high: val + 0, low: val - 5 });
+
+    it('should support increasing the range with domain padding', function() {
+        var data = [obj(5), obj(15)];
+        var extents = linearExtent()
+            .accessors([d => d.high])
+            .paddingStrategy(
+                hardLimitZeroPadding()
+                    .padUnit('domain')
+                    .pad([5, 10])
+            )(data);
+        expect(extents).toEqual([0, 25]);
+    });
+
+    it('should support decreasing the range with domain padding', function() {
+        var data = [obj(5), obj(15)];
+        var extents = linearExtent()
+            .accessors([d => d.high])
+            .paddingStrategy(
+                hardLimitZeroPadding()
+                    .padUnit('domain')
+                    .pad([-5, -2])
+            )(data);
+        expect(extents).toEqual([10, 13]);
+    });
+
+    it('should support increasing the range with domain padding but not cross zero to do so', function() {
+        var data = [obj(1), obj(10)];
+        var extents = linearExtent()
+            .accessors([d => d.high])
+            .paddingStrategy(
+                hardLimitZeroPadding()
+                    .padUnit('domain')
+                    .pad([5, 10])
+            )(data);
+        expect(extents).toEqual([0, 20]);
+    });
+
+    it('should support increasing the range with domain padding normally if extent spans positive to negative values', function() {
+        var data = [obj(-5), obj(5)];
+        var extents = linearExtent()
+            .accessors([d => d.high])
+            .paddingStrategy(
+                hardLimitZeroPadding()
+                    .padUnit('domain')
+                    .pad([5, 5])
+            )(data);
+        expect(extents).toEqual([-10, 10]);
+    });
+});


### PR DESCRIPTION
- examples
- tests (incomplete set for demo purposes)

_Not ready for merge._ A new padding strategy component has been added in this commit. 

For the time being, the tests (and potentially examples) are an incomplete set, as I didn't want to sink too much into them before running the approach through review.

The alternative approach that may be preferred would be effectively overloading the pad() function rather than adding a new paddingStrategy() function. The pad() function then detects whether it's passed a function, in which case that function overrides the defaultPadding(). In the case that it's passed only a number, it behaves in the pre-existing manner.

Alternatively, you might have an entirely different approach in mind, or have cooled on the feature. I hope the examples illustrate the use case for this feature enough to justify it's inclusion. 

This commit resolves #1229 