### PR TITLE
fix: Checks for making sure ReadMes are parsed correctly for docs

### DIFF
--- a/packages/d3fc-site/builder/parseReadmes.js
+++ b/packages/d3fc-site/builder/parseReadmes.js
@@ -8,7 +8,7 @@ const hashes = level => Array(level).fill('#').join('');
 const createBlockPattern = (level) => new RegExp(
   `(${hashes(level)}\\s${title}(?:${any})+?` +
   `(?=(?:\\n${hashes(level)}\\s))|` +
-  `${hashes(level)}\\s${title}(?:${any})+?\\n$)`,
+  `${hashes(level)}\\s${title}(?:${any})+?$)`,
   'g'
 );
 
@@ -77,6 +77,9 @@ export default (readmes) =>
     const structures = readmes
       .map(parseReadme)
       .map(readme => {
+        if (readme.structure.length === 0) {
+          throw new Error(`No content for Readme - ${readme.name}`);
+        }
         delete readme.contents;
         return readme;
       });


### PR DESCRIPTION
Removing the `\\n` from the regex means files that don't end with a line-feed no longer return empty content.

Adding the error check means that if a file does return empty content for any reason, it leads to a build failure rather than an undetected empty page in the docs.

re: #1247, #1248