### PR TITLE
docs: Exclude "Scripts" section in right hand nav panel

### DIFF
--- a/packages/d3fc-site/builder/fetchReadmes.js
+++ b/packages/d3fc-site/builder/fetchReadmes.js
@@ -4,7 +4,8 @@ import glob from 'glob';
 
 const root = path.resolve(__dirname, '../../..');
 
-const readmeGlob = 'packages/d3fc-*/README.md';
+const excludes = ['scripts'];
+const readmeGlob = `packages/d3fc-!(${excludes.join('|')})/README.md`;
 
 const getPackageName = (inputPath) =>
   path.parse(path.resolve(inputPath, '../')).name.replace('d3fc-', '') + '-api';


### PR DESCRIPTION
The Scripts module is used by the build, and should not be included as part of the public documentation.