### PR TITLE
Allow chart axis to set how much width / height it needs

### DIFF
--- a/packages/d3fc-chart/examples/ordinal.html
+++ b/packages/d3fc-chart/examples/ordinal.html
@@ -11,6 +11,12 @@
     <script src="../../d3fc-shape/build/d3fc-shape.js"></script>
     <script src="../../d3fc-annotation/build/d3fc-annotation.js"></script>
     <script src="../build/d3fc-chart.js"></script>
+    <style>
+        .x-axis svg text {
+            font-size: 20px;
+            fill: red;
+        }
+    </style>
 </head>
 <body>
     <div id="ordinal" style="width: 100%; height: 400px"></div>

--- a/packages/d3fc-chart/examples/ordinal.html
+++ b/packages/d3fc-chart/examples/ordinal.html
@@ -13,7 +13,7 @@
     <script src="../build/d3fc-chart.js"></script>
 </head>
 <body>
-    <div id="ordinal" style="width: 500px; height: 250px"></div>
+    <div id="ordinal" style="width: 100%; height: 400px"></div>
     <script src="ordinal.js"></script>
 </body>
 </html>

--- a/packages/d3fc-chart/examples/ordinal.js
+++ b/packages/d3fc-chart/examples/ordinal.js
@@ -60,7 +60,7 @@ const customAxis = (scale) => {
             s.select('text')
                 .style('text-anchor', rotate ? 'end' : 'middle')
                 .attr('transform', rotate ? `translate(0, 3) rotate(-${Math.floor(90 * rotate)} 3 ${Math.floor(labelHeight / 2)})` : 'translate(0, 8)');
-            decorate();
+            decorate(s);
         });
         base(selection);
     }

--- a/packages/d3fc-chart/examples/ordinal.js
+++ b/packages/d3fc-chart/examples/ordinal.js
@@ -1,18 +1,18 @@
 var data = [
     {
-        'month': 'Jan',
+        'month': 'January',
         'sales': 1
     },
     {
-        'month': 'Feb',
+        'month': 'February',
         'sales': 1.5332793661950717
     },
     {
-        'month': 'Mar',
+        'month': 'March',
         'sales': 2.0486834288742597
     },
     {
-        'month': 'Apr',
+        'month': 'April',
         'sales': 2.556310832331535
     },
     {
@@ -20,34 +20,67 @@ var data = [
         'sales': 3.029535759511747
     },
     {
-        'month': 'Jun',
+        'month': 'June',
         'sales': 3.507418002703505
     },
     {
-        'month': 'Jul',
+        'month': 'July',
         'sales': 4.02130992651795
     },
     {
-        'month': 'Aug',
+        'month': 'August',
         'sales': 4.482485234741706
     },
     {
-        'month': 'Sep',
+        'month': 'September',
         'sales': 4.957935275183866
     },
     {
-        'month': 'Oct',
+        'month': 'October',
         'sales': 5.427273488256043
     },
     {
-        'month': 'Nov',
+        'month': 'November',
         'sales': 5.943007604008045
     },
     {
-        'month': 'Dec',
+        'month': 'December',
         'sales': 6.454464059891373
     }
 ];
+
+const customAxis = (scale) => {
+    const base = fc.axisOrdinalBottom(scale);
+    let rotate = false;
+    let decorate = () => {};
+
+    function axis(selection) {
+        base.decorate(function(s) {
+            s.select('text')
+                .style('text-anchor', rotate ? 'end' : 'middle')
+                .attr('transform', rotate ? 'rotate(-45 5 5)' : 'translate(0, 3)');
+            decorate();
+        });
+        base(selection);
+    }
+
+    axis.height = () => {
+        const width = scale.range()[1];
+        rotate = width < 600;
+        return rotate ? '60px': '1em';
+    }
+
+    axis.decorate = (...args) => {
+        if (!args.length) {
+            return decorate;
+        }
+        decorate = args[0];
+        return axis;
+    };
+
+    fc.rebindAll(axis, base, fc.exclude("decorate"));
+    return axis;
+};
 
 var yExtent = fc.extentLinear()
     .accessors([d => d.sales])
@@ -57,10 +90,13 @@ var bar = fc.seriesSvgBar()
     .crossValue(d => d.month)
     .mainValue(d => d.sales);
 
-var chart = fc.chartCartesian(
-        d3.scalePoint().padding(0.5),
-        d3.scaleLinear()
-    )
+var chart = fc.chartCartesian({
+        xScale: d3.scalePoint().padding(0.5),
+        yScale: d3.scaleLinear(),
+        xAxis: {
+            bottom: customAxis
+        }
+    })
     .xLabel('Value')
     .yLabel('Sine / Cosine')
     .yOrient('left')

--- a/packages/d3fc-chart/examples/ordinal.js
+++ b/packages/d3fc-chart/examples/ordinal.js
@@ -65,12 +65,12 @@ const customAxis = (scale) => {
         base(selection);
     }
 
-    axis.height = (d, i, nodes) => {
+    axis.height = selection => {
         const labels = scale.domain();
         const width = scale.range()[1];
 
         // Use a test element to measure the text in the axis SVG container
-        const tester = d3.select(nodes[i]).select('svg')
+        const tester = selection
             .attr('font-size', 10).attr('font-family', 'sans-serif')
             .append('text');
         labelHeight = tester.text("Ty").node().getBBox().height;

--- a/packages/d3fc-chart/examples/ordinal.js
+++ b/packages/d3fc-chart/examples/ordinal.js
@@ -73,15 +73,15 @@ const customAxis = (scale) => {
         const tester = selection
             .attr('font-size', 10).attr('font-family', 'sans-serif')
             .append('text');
-        labelHeight = tester.text("Ty").node().getBBox().height;
+        labelHeight = tester.text('Ty').node().getBBox().height;
         const maxWidth = Math.max(...labels.map(l => tester.text(l).node().getBBox().width));
         tester.remove();
 
         // The more the overlap, the more we rotate
         const allowedSize = labels.length * maxWidth;
         rotate = width < allowedSize ? Math.min(1, (allowedSize / width - 0.8) / 2) : 0;
-        return rotate ? `${Math.floor(maxWidth * rotate + labelHeight) + 10}px`: null;
-    }
+        return rotate ? `${Math.floor(maxWidth * rotate + labelHeight) + 10}px` : null;
+    };
 
     axis.decorate = (...args) => {
         if (!args.length) {
@@ -91,7 +91,7 @@ const customAxis = (scale) => {
         return axis;
     };
 
-    fc.rebindAll(axis, base, fc.exclude("decorate"));
+    fc.rebindAll(axis, base, fc.exclude('decorate'));
     return axis;
 };
 
@@ -104,12 +104,12 @@ var bar = fc.seriesSvgBar()
     .mainValue(d => d.sales);
 
 var chart = fc.chartCartesian({
-        xScale: d3.scalePoint().padding(0.5),
-        yScale: d3.scaleLinear(),
-        xAxis: {
-            bottom: customAxis
-        }
-    })
+    xScale: d3.scalePoint().padding(0.5),
+    yScale: d3.scaleLinear(),
+    xAxis: {
+        bottom: customAxis
+    }
+})
     .xLabel('Value')
     .yLabel('Sine / Cosine')
     .yOrient('left')

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -65,8 +65,8 @@ export default (...args) => {
                 .attr('class', d => `y-label ${d}-label`)
                 .text(yLabel(data));
 
-            xAxisComponent = xOrient(data) === 'top' ? xAxis.top(xScale) : xAxis.bottom(xScale);
-            yAxisComponent = yOrient(data) === 'left' ? yAxis.left(yScale) : yAxis.right(yScale);
+            xAxisComponent = xAxisStore(xOrient(data) === 'top' ? xAxis.top(xScale) : xAxis.bottom(xScale));
+            yAxisComponent = yAxisStore(yOrient(data) === 'left' ? yAxis.left(yScale) : yAxis.right(yScale));
 
             xAxisDataJoin(container, [xOrient(data)])
                 .attr('class', d => `x-axis ${d}-axis`)
@@ -75,7 +75,7 @@ export default (...args) => {
                     if (xScale.range()[1] !== width) {
                         xScale.range([0, width]);
 
-                        select(nodes[i]).style('height', xAxisHeight(data, i, nodes));
+                        select(nodes[i]).style('height', xAxisHeight(select(nodes[i]).select('svg')));
                     }
                 })
                 .on('measure', (d, i, nodes) => {
@@ -91,7 +91,7 @@ export default (...args) => {
                     xAxisComponent.decorate(xDecorate);
                     transitionPropagator(select(nodes[i]))
                         .select('svg')
-                            .call(xAxisStore(xAxisComponent));
+                            .call(xAxisComponent);
                 });
 
             yAxisDataJoin(container, [yOrient(data)])
@@ -101,7 +101,7 @@ export default (...args) => {
                     if (yScale.range()[0] !== height) {
                         yScale.range([height, 0]);
 
-                        select(nodes[i]).style('width', yAxisWidth(data, i, nodes));
+                        select(nodes[i]).style('width', yAxisWidth(select(nodes[i]).select('svg')));
                     }
                 })
                 .on('measure', (d, i, nodes) => {
@@ -117,7 +117,7 @@ export default (...args) => {
                     yAxisComponent.decorate(yDecorate);
                     transitionPropagator(select(nodes[i]))
                         .select('svg')
-                            .call(yAxisStore(yAxisComponent));
+                            .call(yAxisComponent);
                 });
 
             container.select('d3fc-canvas.plot-area')

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -15,8 +15,8 @@ export default (...args) => {
 
     let xLabel = functor('');
     let yLabel = functor('');
-    let xAxisHeight = () => xAxisComponent && xAxisComponent.height ? xAxisComponent.height() : null;
-    let yAxisWidth = () => yAxisComponent && yAxisComponent.height ? yAxisComponent.width() : null;
+    let xAxisHeight = (...args) => xAxisComponent && xAxisComponent.height ? xAxisComponent.height(...args) : null;
+    let yAxisWidth = (...args) => yAxisComponent && yAxisComponent.width ? yAxisComponent.width(...args) : null;
     let yOrient = functor('right');
     let xOrient = functor('bottom');
     let canvasPlotArea = seriesCanvasMulti();
@@ -72,9 +72,11 @@ export default (...args) => {
                 .attr('class', d => `x-axis ${d}-axis`)
                 .on('initialise', (d, i, nodes) => {
                     const { width } = event.detail;
-                    xScale.range([0, width]);
+                    if (xScale.range()[1] !== width) {
+                        xScale.range([0, width]);
 
-                    select(nodes[i]).style('height', xAxisHeight(data));
+                        select(nodes[i]).style('height', xAxisHeight(data, i, nodes));
+                    }
                 })
                 .on('measure', (d, i, nodes) => {
                     const { width, height } = event.detail;
@@ -96,9 +98,11 @@ export default (...args) => {
                 .attr('class', d => `y-axis ${d}-axis`)
                 .on('initialise', (d, i, nodes) => {
                     const { height } = event.detail;
-                    yScale.range([height, 0]);
+                    if (yScale.range()[0] !== height) {
+                        yScale.range([height, 0]);
 
-                    select(nodes[i]).style('width', yAxisWidth(data));
+                        select(nodes[i]).style('width', yAxisWidth(data, i, nodes));
+                    }
                 })
                 .on('measure', (d, i, nodes) => {
                     const { width, height } = event.detail;

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -15,8 +15,8 @@ export default (...args) => {
 
     let xLabel = functor('');
     let yLabel = functor('');
-    let xAxisHeight = functor(null);
-    let yAxisWidth = functor(null);
+    let xAxisHeight = () => xAxisComponent && xAxisComponent.height ? xAxisComponent.height() : null;
+    let yAxisWidth = () => yAxisComponent && yAxisComponent.height ? yAxisComponent.width() : null;
     let yOrient = functor('right');
     let xOrient = functor('bottom');
     let canvasPlotArea = seriesCanvasMulti();
@@ -26,6 +26,9 @@ export default (...args) => {
     let yAxisStore = store('tickFormat', 'ticks', 'tickArguments', 'tickSize', 'tickSizeInner', 'tickSizeOuter', 'tickValues', 'tickPadding', 'tickCenterLabel');
     let yDecorate = () => { };
     let decorate = () => { };
+
+    let xAxisComponent = null;
+    let yAxisComponent = null;
 
     const containerDataJoin = dataJoin('d3fc-group', 'cartesian-chart');
     const xAxisDataJoin = dataJoin('d3fc-svg', 'x-axis')
@@ -62,9 +65,17 @@ export default (...args) => {
                 .attr('class', d => `y-label ${d}-label`)
                 .text(yLabel(data));
 
+            xAxisComponent = xOrient(data) === 'top' ? xAxis.top(xScale) : xAxis.bottom(xScale);
+            yAxisComponent = yOrient(data) === 'left' ? yAxis.left(yScale) : yAxis.right(yScale);
+
             xAxisDataJoin(container, [xOrient(data)])
                 .attr('class', d => `x-axis ${d}-axis`)
-                .style('height', xAxisHeight(data))
+                .on('initialise', (d, i, nodes) => {
+                    const { width } = event.detail;
+                    xScale.range([0, width]);
+
+                    select(nodes[i]).style('height', xAxisHeight(data));
+                })
                 .on('measure', (d, i, nodes) => {
                     const { width, height } = event.detail;
                     if (d === 'top') {
@@ -75,16 +86,20 @@ export default (...args) => {
                     xScale.range([0, width]);
                 })
                 .on('draw', (d, i, nodes) => {
-                    const xAxisComponent = d === 'top' ? xAxis.top(xScale) : xAxis.bottom(xScale);
                     xAxisComponent.decorate(xDecorate);
                     transitionPropagator(select(nodes[i]))
                         .select('svg')
-                        .call(xAxisStore(xAxisComponent));
+                            .call(xAxisStore(xAxisComponent));
                 });
 
             yAxisDataJoin(container, [yOrient(data)])
                 .attr('class', d => `y-axis ${d}-axis`)
-                .style('width', yAxisWidth(data))
+                .on('initialise', (d, i, nodes) => {
+                    const { height } = event.detail;
+                    yScale.range([height, 0]);
+
+                    select(nodes[i]).style('width', yAxisWidth(data));
+                })
                 .on('measure', (d, i, nodes) => {
                     const { width, height } = event.detail;
                     if (d === 'left') {
@@ -95,11 +110,10 @@ export default (...args) => {
                     yScale.range([height, 0]);
                 })
                 .on('draw', (d, i, nodes) => {
-                    const yAxisComponent = d === 'left' ? yAxis.left(yScale) : yAxis.right(yScale);
                     yAxisComponent.decorate(yDecorate);
                     transitionPropagator(select(nodes[i]))
                         .select('svg')
-                        .call(yAxisStore(yAxisComponent));
+                            .call(yAxisStore(yAxisComponent));
                 });
 
             container.select('d3fc-canvas.plot-area')

--- a/packages/d3fc-element/src/redraw.js
+++ b/packages/d3fc-element/src/redraw.js
@@ -25,6 +25,13 @@ const initialise = (element) => {
     element.dispatchEvent(event);
 };
 
+const initialiseIfResized = (element) => {
+    const detail = data.get(element);
+    if (detail.resized) {
+        initialise(element);
+    }
+};
+
 const resize = (element) => {
     const detail = data.get(element);
     const event = new CustomEvent('measure', { detail });
@@ -42,6 +49,8 @@ export default (elements) => {
       .reduce((a, b) => a.concat(b));
     allElements.forEach(measure);
     allElements.forEach(initialise);
+    allElements.forEach(measure);
+    allElements.forEach(initialiseIfResized);
     allElements.forEach(measure);
     allElements.forEach(resize);
     allElements.forEach(draw);

--- a/packages/d3fc-element/src/redraw.js
+++ b/packages/d3fc-element/src/redraw.js
@@ -19,6 +19,12 @@ if (typeof CustomEvent !== 'function') {
     throw new Error('d3fc-element depends on CustomEvent. Make sure that you load a polyfill in older browsers. See README.');
 }
 
+const initialise = (element) => {
+    const detail = data.get(element);
+    const event = new CustomEvent('initialise', { detail });
+    element.dispatchEvent(event);
+};
+
 const resize = (element) => {
     const detail = data.get(element);
     const event = new CustomEvent('measure', { detail });
@@ -34,6 +40,8 @@ const draw = (element) => {
 export default (elements) => {
     const allElements = elements.map(find)
       .reduce((a, b) => a.concat(b));
+    allElements.forEach(measure);
+    allElements.forEach(initialise);
     allElements.forEach(measure);
     allElements.forEach(resize);
     allElements.forEach(draw);


### PR DESCRIPTION
Introduces a new "initialise" event to the d3fc-element, allowing it to allocate the amount of space it needs.

"initialise" is called a second time on any for any element that has had it's available space adjusted by other components in the group (e.g. for X and Y axis affecting each other).

Implemented a new property `labelRotate` of the `axisOrdinal` component. Can be set to "auto" to automatically rotate the labels based on the available space, or else to a number to fix the rotation angle (in degrees).

Examples included: `d3fc-chart/examples/ordinal.html` and `d3fc-axis/examples/rotate.html`