### PR TITLE
[WIP] better error reporting

### DIFF
--- a/packages/d3fc-series/src/svg/area.js
+++ b/packages/d3fc-series/src/svg/area.js
@@ -4,6 +4,7 @@ import {select} from 'd3-selection';
 import {rebind, exclude, rebindAll} from '@d3fc/d3fc-rebind';
 import xyBase from '../xyBase';
 import colors from '../colors';
+import {assertIsSelection} from './assert';
 
 export default () => {
     const base = xyBase();
@@ -13,6 +14,8 @@ export default () => {
     const join = dataJoin('path', 'area');
 
     const area = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/assert.js
+++ b/packages/d3fc-series/src/svg/assert.js
@@ -1,0 +1,7 @@
+import {selection} from 'd3-selection';
+
+export const assertIsSelection = (sel) => {
+    if (!(sel instanceof selection)) {
+        throw new Error('Series components must be invoked with a D3 selection. If you are using in conjunction with d3fc chart, check you are adding the series to an svgPlotArea');
+    }
+};

--- a/packages/d3fc-series/src/svg/bar.js
+++ b/packages/d3fc-series/src/svg/bar.js
@@ -4,6 +4,7 @@ import { select } from 'd3-selection';
 import xyBase from '../xyBase';
 import { rebind, rebindAll } from '@d3fc/d3fc-rebind';
 import colors from '../colors';
+import { assertIsSelection } from './assert';
 
 export default () => {
 
@@ -25,6 +26,8 @@ export default () => {
         'translate(' + origin[0] + ', ' + origin[1] + ')';
 
     const bar = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/boxPlot.js
+++ b/packages/d3fc-series/src/svg/boxPlot.js
@@ -5,6 +5,7 @@ import { rebind, rebindAll } from '@d3fc/d3fc-rebind';
 import { select } from 'd3-selection';
 import boxPlotBase from '../boxPlotBase';
 import colors from '../colors';
+import { assertIsSelection } from './assert';
 
 export default () => {
 
@@ -22,6 +23,8 @@ export default () => {
         (values) => 'translate(' + values.origin[0] + ', ' + values.origin[1] + ')';
 
     const boxPlot = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/errorBar.js
+++ b/packages/d3fc-series/src/svg/errorBar.js
@@ -5,6 +5,7 @@ import { rebind, rebindAll } from '@d3fc/d3fc-rebind';
 import { select } from 'd3-selection';
 import errorBarBase from '../errorBarBase';
 import colors from '../colors';
+import { assertIsSelection } from './assert';
 
 export default () => {
 
@@ -22,6 +23,8 @@ export default () => {
         (values) => 'translate(' + values.origin[0] + ', ' + values.origin[1] + ')';
 
     const errorBar = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/grouped.js
+++ b/packages/d3fc-series/src/svg/grouped.js
@@ -1,10 +1,8 @@
-import { scaleBand } from 'd3-scale';
 import { dataJoin } from '@d3fc/d3fc-data-join';
 import { select } from 'd3-selection';
-import { range } from 'd3-array';
 import { rebindAll, exclude } from '@d3fc/d3fc-rebind';
 import groupedBase from '../groupedBase';
-import alignOffset from '../alignOffset';
+import { assertIsSelection } from './assert';
 
 export default (series) => {
 
@@ -13,6 +11,8 @@ export default (series) => {
     const join = dataJoin('g', 'grouped');
 
     const grouped = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/heatmap.js
+++ b/packages/d3fc-series/src/svg/heatmap.js
@@ -1,9 +1,8 @@
-import { scaleLinear } from 'd3-scale';
 import { dataJoin } from '@d3fc/d3fc-data-join';
-import { min, max } from 'd3-array';
 import { select } from 'd3-selection';
 import { rebindAll } from '@d3fc/d3fc-rebind';
 import heatmapBase from '../heatmapBase';
+import { assertIsSelection } from './assert';
 
 export default () => {
 
@@ -16,6 +15,8 @@ export default () => {
         ', ' + values.y + ')';
 
     const heatmap = (selection) => {
+
+        assertIsSelection(selection);
 
         selection.each((data, index, group) => {
 

--- a/packages/d3fc-series/src/svg/line.js
+++ b/packages/d3fc-series/src/svg/line.js
@@ -4,6 +4,7 @@ import {select} from 'd3-selection';
 import {rebind, exclude, rebindAll} from '@d3fc/d3fc-rebind';
 import xyBase from '../xyBase';
 import colors from '../colors';
+import { assertIsSelection } from './assert';
 
 export default () => {
     const base = xyBase();
@@ -15,6 +16,8 @@ export default () => {
     const join = dataJoin('path', 'line');
 
     const line = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/multi.js
+++ b/packages/d3fc-series/src/svg/multi.js
@@ -2,6 +2,7 @@ import {dataJoin} from '@d3fc/d3fc-data-join';
 import {select} from 'd3-selection';
 import {rebindAll, rebind} from '@d3fc/d3fc-rebind';
 import multiBase from '../multiBase';
+import { assertIsSelection } from './assert';
 
 export default () => {
 
@@ -12,6 +13,8 @@ export default () => {
     const join = dataJoin('g', 'multi');
 
     const multi = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/ohlcBase.js
+++ b/packages/d3fc-series/src/svg/ohlcBase.js
@@ -1,9 +1,9 @@
 import { dataJoin } from '@d3fc/d3fc-data-join';
-import { shapeCandlestick } from '@d3fc/d3fc-shape';
 import ohlcBase from '../ohlcBase';
 import { rebind, rebindAll } from '@d3fc/d3fc-rebind';
 import { select } from 'd3-selection';
 import colors from '../colors';
+import { assertIsSelection } from './assert';
 
 export default (pathGenerator, seriesName) => {
     const base = ohlcBase();
@@ -15,6 +15,8 @@ export default (pathGenerator, seriesName) => {
         maybeTransition.selection ? selection.transition(maybeTransition) : selection;
 
     const candlestick = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/point.js
+++ b/packages/d3fc-series/src/svg/point.js
@@ -4,6 +4,7 @@ import {select} from 'd3-selection';
 import {rebind, exclude, rebindAll} from '@d3fc/d3fc-rebind';
 import xyBase from '../xyBase';
 import colors from '../colors';
+import { assertIsSelection } from './assert';
 
 export default () => {
     const symbol = symbolShape();
@@ -16,6 +17,8 @@ export default () => {
         'translate(' + origin[0] + ', ' + origin[1] + ')';
 
     const point = (selection) => {
+
+        assertIsSelection(selection);
 
         if (selection.selection) {
             join.transition(selection);

--- a/packages/d3fc-series/src/svg/repeat.js
+++ b/packages/d3fc-series/src/svg/repeat.js
@@ -2,6 +2,7 @@ import {select} from 'd3-selection';
 import {rebindAll, exclude} from '@d3fc/d3fc-rebind';
 import multiSeries from './multi';
 import line from './line';
+import { assertIsSelection } from './assert';
 
 export default () => {
 
@@ -9,7 +10,10 @@ export default () => {
     let series = line();
     const multi = multiSeries();
 
-    const repeat = (selection) =>
+    const repeat = (selection) => {
+
+        assertIsSelection(selection);
+
         selection.each((data, index, group) => {
             if (orient === 'vertical') {
                 multi.series(data[0].map(_ => series))
@@ -20,6 +24,7 @@ export default () => {
             }
             select(group[index]).call(multi);
         });
+    };
 
     repeat.series = (...args) => {
         if (!args.length) {

--- a/packages/d3fc-series/test/baseSpec.js
+++ b/packages/d3fc-series/test/baseSpec.js
@@ -1,4 +1,4 @@
-import * as d3Scale from 'd3-scale';
+/* global d3 */
 import * as fc from '../index';
 
 describe('xScale', () => {
@@ -23,6 +23,29 @@ describe('xScale', () => {
         });
     });
 
+});
+
+describe('SVG error reporting', () => {
+
+    let svgSeries;
+
+    beforeEach(() => (svgSeries = getSvgSeries()));
+
+    it('should not throw if supplied with a data-joined selection', () => {
+        svgSeries.forEach(series => {
+            const selection = d3.select('body').datum([]);
+            selection.call(series);
+        });
+    });
+
+    it('should throw if invoked with a non-selection', () => {
+        const notASelection = () => {};
+        svgSeries.forEach(series => {
+            expect(() => {
+                series(notASelection);
+            }).toThrow(new Error('Series components must be invoked with a D3 selection. If you are using in conjunction with d3fc chart, check you are adding the series to an svgPlotArea'));
+        });
+    });
 });
 
 describe('yScale', () => {

--- a/packages/d3fc-series/test/helpers/beforeEachSpec.js
+++ b/packages/d3fc-series/test/helpers/beforeEachSpec.js
@@ -1,2 +1,4 @@
 import jsdom from 'jsdom';
+import { select } from 'd3-selection';
 global.document = jsdom.jsdom();
+global.d3 = { select };


### PR DESCRIPTION
in reference to #1259 - there are a number of simple validations and error reporting we could perform to make d3fc a little easier to use. For example:

 - [x] ensure svg series are passed a selection
 - [ ] ensure selections have 'bound' data
 - [ ] ensure canvas series are passed an array of data

@chrisprice WDYT?