### PR TITLE
fix: draw canvas plot area behind svg

### DIFF
--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -50,8 +50,8 @@ export default (...args) => {
             container.enter()
                 .attr('auto-resize', '')
                 .html(
-                    '<d3fc-svg class="plot-area"></d3fc-svg>' +
-                    '<d3fc-canvas class="plot-area"></d3fc-canvas>'
+                    '<d3fc-canvas class="plot-area"></d3fc-canvas>' +
+                    '<d3fc-svg class="plot-area"></d3fc-svg>'
                 );
 
             xLabelDataJoin(container, [xOrient(data)])


### PR DESCRIPTION
Since you can't interact with a canvas plot area (in the same way) would it make sense to draw the canvas behind the svg? This would mean you wouldn't have to hide/delete the canvas plot to interact with the svg.