### PR TITLE
chore: migrate examples to chartCartesian

### DIFF
--- a/packages/d3fc-brush/examples/brush.js
+++ b/packages/d3fc-brush/examples/brush.js
@@ -49,11 +49,11 @@ var multi = fc.seriesSvgMulti()
         }
     });
 
-var mainChart = fc.chartSvgCartesian(x, y)
-    .plotArea(area);
+var mainChart = fc.chartCartesian(x, y)
+    .svgPlotArea(area);
 
-var navigatorChart = fc.chartSvgCartesian(x.copy(), y.copy())
-    .plotArea(multi);
+var navigatorChart = fc.chartCartesian(x.copy(), y.copy())
+    .svgPlotArea(multi);
 
 // set the initial domain based on the brushed range
 var scale = d3.scaleLinear().domain(x.domain());

--- a/packages/d3fc-brush/examples/brushZoom.js
+++ b/packages/d3fc-brush/examples/brushZoom.js
@@ -68,8 +68,8 @@ var multi = fc.seriesSvgMulti()
         }
     });
 
-var mainChart = fc.chartSvgCartesian(x, y)
-  .plotArea(multi);
+var mainChart = fc.chartCartesian(x, y)
+  .svgPlotArea(multi);
 
 function render() {
     d3.select('#main-chart')

--- a/packages/d3fc-chart/examples/chart.js
+++ b/packages/d3fc-chart/examples/chart.js
@@ -71,12 +71,13 @@ d3.select('#sine-svg')
 
 // and now in canvas ...
 
+var gridlinesCanvas = fc.annotationCanvasGridline();
 var areaCanvas = fc.seriesCanvasArea()
   .mainValue(d => d.z);
 var lineCanvas = fc.seriesCanvasLine();
 
 var multiCanvas = fc.seriesCanvasMulti()
-  .series([areaCanvas, lineCanvas]);
+  .series([gridlinesCanvas, areaCanvas, lineCanvas]);
 
 var chartCanvas = fc.chartCanvasCartesian(
     d3.scaleLinear(),

--- a/packages/d3fc-chart/examples/custom-axis.html
+++ b/packages/d3fc-chart/examples/custom-axis.html
@@ -11,6 +11,12 @@
     <script src="../../d3fc-shape/build/d3fc-shape.js"></script>
     <script src="../../d3fc-annotation/build/d3fc-annotation.js"></script>
     <script src="../build/d3fc-chart.js"></script>
+
+    <style>
+        div.y-label {
+            transform: rotate(-90deg);
+        }
+    </style>
 </head>
 <body>
     <div id="custom-axis" style="width: 500px; height: 250px"></div>

--- a/packages/d3fc-chart/examples/custom-axis.html
+++ b/packages/d3fc-chart/examples/custom-axis.html
@@ -11,12 +11,6 @@
     <script src="../../d3fc-shape/build/d3fc-shape.js"></script>
     <script src="../../d3fc-annotation/build/d3fc-annotation.js"></script>
     <script src="../build/d3fc-chart.js"></script>
-
-    <style>
-        div.y-label {
-            transform: rotate(-90deg);
-        }
-    </style>
 </head>
 <body>
     <div id="custom-axis" style="width: 500px; height: 250px"></div>

--- a/packages/d3fc-chart/examples/custom-axis.js
+++ b/packages/d3fc-chart/examples/custom-axis.js
@@ -48,7 +48,7 @@ var area = fc.seriesSvgArea()
 var multi = fc.seriesSvgMulti()
     .series([gridlines, area, line]);
 
-var chart = fc.chartSvgCartesian({
+var chart = fc.chartCartesian({
     xScale: d3.scaleLinear(),
     yScale: d3.scaleLinear(),
     xAxis: {
@@ -64,7 +64,7 @@ var chart = fc.chartSvgCartesian({
     .yTicks([5])
     .yDomain(yExtent(data))
     .xDomain(xExtent(data))
-    .plotArea(multi);
+    .svgPlotArea(multi);
 
 d3.select('#custom-axis')
     .datum(data)


### PR DESCRIPTION
In relation to #1262, migrated examples to use `chartCartesian`.