### PR TITLE
feat: add y label container to chartCartesian

### DIFF
--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -34,6 +34,7 @@ export default (...args) => {
         .key(d => d);
     const xLabelDataJoin = dataJoin('div', 'x-label')
         .key(d => d);
+    const yContainerDataJoin = dataJoin('div', 'y-label-container');
     const yLabelDataJoin = dataJoin('div', 'y-label')
         .key(d => d);
 
@@ -58,8 +59,16 @@ export default (...args) => {
                 .attr('class', d => `x-label ${d}-label`)
                 .text(xLabel(data));
 
-            yLabelDataJoin(container, [yOrient(data)])
-                .attr('class', d => `y-label ${d}-label`)
+            const yOrientValue = yOrient(data);
+            const yLabelContainer = yContainerDataJoin(container, [yOrientValue])
+                .attr('class', d => `y-label-container ${d}-label`)
+                .style('grid-column', yOrientValue === 'left' ? 1 : 5)
+                .style('-ms-grid-column', yOrientValue === 'left' ? 1 : 5)
+                .style('grid-row', 3)
+                .style('-ms-grid-row', 3);
+
+            yLabelDataJoin(yLabelContainer, [yOrientValue])
+                .attr('class', 'y-label')
                 .text(yLabel(data));
 
             xAxisDataJoin(container, [xOrient(data)])

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -34,8 +34,7 @@ export default (...args) => {
         .key(d => d);
     const xLabelDataJoin = dataJoin('div', 'x-label')
         .key(d => d);
-    const yContainerDataJoin = dataJoin('div', 'y-label-container');
-    const yLabelDataJoin = dataJoin('div', 'y-label')
+    const yContainerDataJoin = dataJoin('div', 'y-label-container')
         .key(d => d);
 
     const propagateTransition = maybeTransition => selection =>
@@ -67,8 +66,13 @@ export default (...args) => {
                 .style('grid-row', 3)
                 .style('-ms-grid-row', 3);
 
-            yLabelDataJoin(yLabelContainer, [yOrientValue])
-                .attr('class', 'y-label')
+            yLabelContainer
+                .enter()
+                .append('div')
+                .attr('class', 'y-label');
+
+            yLabelContainer
+                .select('.y-label')
                 .text(yLabel(data));
 
             xAxisDataJoin(container, [xOrient(data)])

--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -60,11 +60,7 @@ export default (...args) => {
 
             const yOrientValue = yOrient(data);
             const yLabelContainer = yContainerDataJoin(container, [yOrientValue])
-                .attr('class', d => `y-label-container ${d}-label`)
-                .style('grid-column', yOrientValue === 'left' ? 1 : 5)
-                .style('-ms-grid-column', yOrientValue === 'left' ? 1 : 5)
-                .style('grid-row', 3)
-                .style('-ms-grid-row', 3);
+                .attr('class', d => `y-label-container ${d}-label`);
 
             yLabelContainer
                 .enter()

--- a/packages/d3fc-chart/src/cartesianBase.js
+++ b/packages/d3fc-chart/src/cartesianBase.js
@@ -24,15 +24,6 @@ export default (setPlotArea, defaultPlotArea) =>
                     .style('height', '1em')
                     .style('line-height', '1em');
 
-                container
-                    .select('div.y-label-container')
-                    .style('display', 'flex')
-                    .style('align-items', 'center')
-                    .style('justify-content', 'center')
-                    .style('width', '1em')
-                    .select('div.y-label')
-                    .style('transform', 'rotate(-90deg)');
-
                 container.select('.y-label-container>.y-label')
                     .text(yLabel);
 

--- a/packages/d3fc-chart/src/cartesianBase.js
+++ b/packages/d3fc-chart/src/cartesianBase.js
@@ -24,21 +24,13 @@ export default (setPlotArea, defaultPlotArea) =>
                     .style('height', '1em')
                     .style('line-height', '1em');
 
-                const yOrientValue = cartesian.yOrient()(data);
-
-                container.enter()
-                    .append('div')
-                    .attr('class', 'y-label-container')
-                    .style('grid-column', yOrientValue === 'left' ? 1 : 5)
-                    .style('-ms-grid-column', yOrientValue === 'left' ? 1 : 5)
-                    .style('grid-row', 3)
-                    .style('-ms-grid-row', 3)
-                    .style('width', '1em')
+                container
+                    .select('div.y-label-container')
                     .style('display', 'flex')
                     .style('align-items', 'center')
                     .style('justify-content', 'center')
-                    .append('div')
-                    .attr('class', 'y-label')
+                    .style('width', '1em')
+                    .select('div.y-label')
                     .style('transform', 'rotate(-90deg)');
 
                 container.select('.y-label-container>.y-label')

--- a/packages/d3fc-chart/src/css.js
+++ b/packages/d3fc-chart/src/css.js
@@ -2,13 +2,15 @@
 export const css = `d3fc-group.cartesian-chart{width:100%;height:100%;overflow:hidden;display:grid;display:-ms-grid;grid-template-columns:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);-ms-grid-columns:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);grid-template-rows:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);-ms-grid-rows:minmax(1em,max-content) auto 1fr auto minmax(1em,max-content);}
 d3fc-group.cartesian-chart>.top-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;-ms-grid-row:1;-ms-grid-row:1;}
 d3fc-group.cartesian-chart>.top-axis{height:2em;grid-column:3;-ms-grid-column:3;grid-row:2;-ms-grid-row:2;}
-d3fc-group.cartesian-chart>.left-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:1;-ms-grid-column:1;grid-row:3;-ms-grid-row:3;}
+d3fc-group.cartesian-chart>.left-label{white-space:nowrap;align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:1;-ms-grid-column:1;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.left-axis{width:3em;grid-column:2;-ms-grid-column:2;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.plot-area{overflow:hidden;grid-column:3;-ms-grid-column:3;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.right-axis{width:3em;grid-column:4;-ms-grid-column:4;grid-row:3;-ms-grid-row:3;}
-d3fc-group.cartesian-chart>.right-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:5;-ms-grid-column:5;grid-row:3;-ms-grid-row:3;}
+d3fc-group.cartesian-chart>.right-label{white-space:nowrap;align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:5;-ms-grid-column:5;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.bottom-axis{height:2em;grid-column:3;-ms-grid-column:3;grid-row:4;-ms-grid-row:4;}
-d3fc-group.cartesian-chart>.bottom-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;grid-row:5;-ms-grid-row:5;}`;
+d3fc-group.cartesian-chart>.bottom-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;grid-row:5;-ms-grid-row:5;}
+d3fc-group.cartesian-chart>.y-label-container{width:1em;}
+d3fc-group.cartesian-chart>.y-label-container>.y-label{align-items:center;justify-content:center;display:flex;transform:rotate(-90deg);}`;
 
 const styleElement = document.createElement('style');
 styleElement.setAttribute('type', 'text/css');


### PR DESCRIPTION
I'm sure this needs some refactoring but this PR moves the `y-label-container` div from `cartesianBase` to `chartCartesian`, in reference to #1262, for easier styling of the label.