### PR TITLE
Y label styling

### DIFF
--- a/packages/d3fc-chart/src/cartesianBase.js
+++ b/packages/d3fc-chart/src/cartesianBase.js
@@ -37,6 +37,7 @@ export default (setPlotArea, defaultPlotArea) =>
                     .style('display', 'flex')
                     .style('align-items', 'center')
                     .style('justify-content', 'center')
+                    .style('white-space', 'nowrap')
                     .append('div')
                     .attr('class', 'y-label')
                     .style('transform', 'rotate(-90deg)');

--- a/packages/d3fc-chart/src/css.js
+++ b/packages/d3fc-chart/src/css.js
@@ -8,7 +8,8 @@ d3fc-group.cartesian-chart>.plot-area{overflow:hidden;grid-column:3;-ms-grid-col
 d3fc-group.cartesian-chart>.right-axis{width:3em;grid-column:4;-ms-grid-column:4;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.right-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:5;-ms-grid-column:5;grid-row:3;-ms-grid-row:3;}
 d3fc-group.cartesian-chart>.bottom-axis{height:2em;grid-column:3;-ms-grid-column:3;grid-row:4;-ms-grid-row:4;}
-d3fc-group.cartesian-chart>.bottom-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;grid-row:5;-ms-grid-row:5;}`;
+d3fc-group.cartesian-chart>.bottom-label{align-self:center;-ms-grid-column-align:center;justify-self:center;-ms-grid-row-align:center;grid-column:3;-ms-grid-column:3;grid-row:5;-ms-grid-row:5;}
+d3fc-group.cartesian-chart>.y-label{display:flex;transform:rotate(-90deg);width:1em;white-space:nowrap;justify-content:center;}`;
 
 const styleElement = document.createElement('style');
 styleElement.setAttribute('type', 'text/css');


### PR DESCRIPTION
This is an alternative to #1267 (related to #1262). The `y-label-container` seems to not be necessary, this PR applies the vertical y-label styling by default.