### PR TITLE
chore: migrate site examples to chartCartesian

### DIFF
--- a/packages/d3fc-brush/README.md
+++ b/packages/d3fc-brush/README.md
@@ -60,11 +60,11 @@ var multi = fc.seriesSvgMulti()
 The main and navigator charts are rendered using the cartesian chart component, with the navigator using the multi series defined above:
 
 ~~~javascript
-var mainChart = fc.chartSvgCartesian(x, y)
-    .plotArea(area);
+var mainChart = fc.chartCartesian(x, y)
+    .svgPlotArea(area);
 
-var navigatorChart = fc.chartSvgCartesian(x.copy(), y.copy())
-    .plotArea(multi);
+var navigatorChart = fc.chartCartesian(x.copy(), y.copy())
+    .svgPlotArea(multi);
 
 function render() {
     d3.select('#main-chart')

--- a/packages/d3fc-site/src/404.js
+++ b/packages/d3fc-site/src/404.js
@@ -39,14 +39,14 @@ var pointSeries = fc.seriesSvgPoint()
           .attr('fill', function(d) { return color(d.type); });
     });
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
               d3.scaleLinear(),
               d3.scaleLinear()
             )
     .xDomain([0, 13])
     .yDomain([0, 13])
     .yOrient('left')
-    .plotArea(pointSeries);
+    .svgPlotArea(pointSeries);
 
 d3.select('#chart-404')
     .datum(data)

--- a/packages/d3fc-site/src/examples/bubble/bubble.js
+++ b/packages/d3fc-site/src/examples/bubble/bubble.js
@@ -26,7 +26,7 @@ d3.json('https://d3fc.io/examples/bubble/data.json').then(function(data) {
             .attr('fill', function(d) { return color(d.region); });
       });
 
-  var chart = fc.chartSvgCartesian(
+  var chart = fc.chartCartesian(
                 d3.scaleLog(),
                 d3.scaleLinear()
               )
@@ -39,7 +39,7 @@ d3.json('https://d3fc.io/examples/bubble/data.json').then(function(data) {
       .yLabel('Life expectancy (years)')
       .xTicks(2, d3.format(',d'))
       .yOrient('left')
-      .plotArea(pointSeries)
+      .svgPlotArea(pointSeries)
       .decorate(function(selection) {
         // append an svg for the d3-legend
         selection.enter()

--- a/packages/d3fc-site/src/examples/simple/simple.js
+++ b/packages/d3fc-site/src/examples/simple/simple.js
@@ -19,7 +19,7 @@ var xExtent = fc.extentLinear()
   .accessors([function(d) { return d.x; }]);
 
 // create a chart
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
     d3.scaleLinear(),
     d3.scaleLinear())
   .yDomain(yExtent(data))
@@ -53,7 +53,7 @@ var gridlines = fc.annotationSvgGridline();
 var multi = fc.seriesSvgMulti()
   .series([gridlines, sinLine, cosLine]);
 
-chart.plotArea(multi);
+chart.svgPlotArea(multi);
 
 // render
 d3.select('#simple-chart')

--- a/packages/d3fc-site/src/examples/stacked/stacked.js
+++ b/packages/d3fc-site/src/examples/stacked/stacked.js
@@ -39,7 +39,7 @@ d3.csv('https://d3fc.io/examples/stacked/data.csv').then(function(data) {
     .pad([0, 1])
     .padUnit('domain');
 
-  var chart = fc.chartSvgCartesian(
+  var chart = fc.chartCartesian(
       d3.scaleLinear(),
       d3.scalePoint())
     .xDomain(xExtent(series))
@@ -50,7 +50,7 @@ d3.csv('https://d3fc.io/examples/stacked/data.csv').then(function(data) {
     .yPadding([0.5])
     .xLabel('Million tonnes of oil equivalent')
     .chartLabel('2013 Energy Production')
-    .plotArea(multi)
+    .svgPlotArea(multi)
     .decorate(function(selection, data, index) {
       // append an svg for the d3-legend
       selection.enter()

--- a/packages/d3fc-site/src/examples/streaming/streaming.js
+++ b/packages/d3fc-site/src/examples/streaming/streaming.js
@@ -43,7 +43,7 @@ function renderChart() {
     ]);
 
   // create a chart
-  const chart = fc.chartSvgCartesian(
+  const chart = fc.chartCartesian(
       d3.scaleTime(),
       d3.scaleLinear()
     )
@@ -104,7 +104,7 @@ function renderChart() {
   const multi = fc.seriesSvgMulti()
     .series([gridlines, bollingerBands(), candlestick]);
 
-  chart.plotArea(multi);
+  chart.svgPlotArea(multi);
 
   container
     .style('margin-left', '20px')

--- a/packages/d3fc-site/src/examples/zoom/zoom.js
+++ b/packages/d3fc-site/src/examples/zoom/zoom.js
@@ -28,9 +28,9 @@ var zoom = d3.zoom()
   });
 
 // the chart!
-var chart = fc.chartCanvasCartesian(x, y)
+var chart = fc.chartCartesian(x, y)
   .chartLabel('Canvas Zoom 10,000 Points')
-  .plotArea(area)
+  .canvasPlotArea(area)
   .decorate((sel) => {
     // add the zoom interaction on the enter selection
     // NOTE: there is a much better zoom integration being developed

--- a/packages/d3fc-site/src/introduction/adding-annotations.js
+++ b/packages/d3fc-site/src/introduction/adding-annotations.js
@@ -30,7 +30,7 @@ var data = {
   })
 };
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
         d3.scaleBand(),
         d3.scaleLinear())
     .chartLabel('2015 Cumulative Sales')
@@ -61,7 +61,7 @@ var multi = fc.seriesSvgMulti()
       }
     });
 
-chart.plotArea(multi);
+chart.svgPlotArea(multi);
 // END
 
 d3.select('#adding-annotations')

--- a/packages/d3fc-site/src/introduction/building-a-chart-complete.js
+++ b/packages/d3fc-site/src/introduction/building-a-chart-complete.js
@@ -29,7 +29,7 @@ var data = {
   })
 };
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
         d3.scaleBand(),
         d3.scaleLinear())
     .chartLabel('2015 Cumulative Sales')
@@ -82,7 +82,7 @@ var multi = fc.seriesSvgMulti()
       }
     });
 
-chart.plotArea(multi);
+chart.svgPlotArea(multi);
 
 d3.selectAll('.complete-chart')
     .datum(data)

--- a/packages/d3fc-site/src/introduction/cartesian-chart-extent.js
+++ b/packages/d3fc-site/src/introduction/cartesian-chart-extent.js
@@ -19,7 +19,7 @@ var yExtent = fc.extentLinear()
     .pad([0, 0.5])
     .accessors([function(d) { return d.sales; }]);
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
         d3.scaleBand(),
         d3.scaleLinear())
     .xDomain(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
@@ -32,7 +32,7 @@ var series = fc.autoBandwidth(fc.seriesSvgBar())
     .crossValue(function(d) { return d.month; })
     .mainValue(function(d) { return d.sales; });
 
-chart.plotArea(series);
+chart.svgPlotArea(series);
 
 d3.select('#cartesian-extent')
     .datum(data)

--- a/packages/d3fc-site/src/introduction/cartesian-chart.js
+++ b/packages/d3fc-site/src/introduction/cartesian-chart.js
@@ -14,7 +14,7 @@ var data = generator(1).map(function(d, i) {
 });
 
 // START
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
         d3.scaleBand(),
         d3.scaleLinear())
     .xDomain(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
@@ -26,7 +26,7 @@ var series = fc.autoBandwidth(fc.seriesSvgBar())
     .crossValue(function(d) { return d.month; })
     .mainValue(function(d) { return d.sales; });
 
-chart.plotArea(series);
+chart.svgPlotArea(series);
 
 d3.select('#cartesian')
     .datum(data)

--- a/packages/d3fc-site/src/introduction/getting-started.js
+++ b/packages/d3fc-site/src/introduction/getting-started.js
@@ -14,13 +14,13 @@ var candlestick = fc.seriesSvgCandlestick();
 var multi = fc.seriesSvgMulti()
     .series([gridlines, candlestick]);
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
     fc.scaleDiscontinuous(d3.scaleTime()),
     d3.scaleLinear()
   )
   .yDomain(yExtent(data))
   .xDomain(xExtent(data))
-  .plotArea(multi);
+  .svgPlotArea(multi);
 
 d3.select('#chart')
   .datum(data)

--- a/packages/d3fc-site/src/introduction/tidy-chart.js
+++ b/packages/d3fc-site/src/introduction/tidy-chart.js
@@ -21,7 +21,7 @@ var yExtent = fc.extentLinear()
 // START
 var valueformatter = d3.format('$.0f');
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
         d3.scaleBand(),
         d3.scaleLinear())
     .chartLabel('2015 Cumulative Sales')
@@ -39,7 +39,7 @@ var series = fc.autoBandwidth(fc.seriesSvgBar())
     .crossValue(function(d) { return d.month; })
     .mainValue(function(d) { return d.sales; });
 
-chart.plotArea(series);
+chart.svgPlotArea(series);
 
 d3.select('#tidied-chart')
     .datum(data)

--- a/packages/d3fc-site/src/introduction/transitions.js
+++ b/packages/d3fc-site/src/introduction/transitions.js
@@ -7,11 +7,11 @@ var barSeries = fc.seriesSvgBar()
     .crossValue(function(_, i) { return i; })
     .mainValue(function(d) { return d; });
 
-var chart = fc.chartSvgCartesian(
+var chart = fc.chartCartesian(
               d3.scaleLinear(),
               d3.scaleLinear())
     .xDomain([-1, data.length])
-    .plotArea(barSeries);
+    .svgPlotArea(barSeries);
 
 var index = 0;
 function render() {


### PR DESCRIPTION
This PR should cover the remaining references to the legacy cartesian components. I've changed all the file but I don't think they're all on the website.