### PR TITLE
Use classed instead of  attr('class')

### DIFF
--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -54,9 +54,11 @@ export default (...args) => {
             container.enter()
                 .attr('auto-resize', '');
 
-            chartLabelDataJoin(container, [xOrient(data)])
-                .attr('class', d => d === 'top' ? 'bottom-label' : 'top-label')
-                .style('margin-bottom', d => d === 'top' ? 0 : '1em')
+            const label = chartLabelDataJoin(container, [xOrient(data)])
+                .classed('bottom-label', d => d === 'top')
+                .classed('top-label', d => d !== 'top');
+            
+            label.style('margin-bottom', d => d === 'top' ? 0 : '1em')
                 .style('margin-top', d => d === 'top' ? '1em' : 0)
                 .text(chartLabel(data));
 


### PR DESCRIPTION
This seems that using the attr('class') was removing the "chart-label" applied on the dataJoin. This resulted in recreating the container every time... (Be advised I'm clueless as to why, I just know it works...)