### PR TITLE
Add typescript demonstration for Candlestick type

### DIFF
--- a/packages/d3fc-shape/src/index.d.ts
+++ b/packages/d3fc-shape/src/index.d.ts
@@ -8,7 +8,7 @@
 /**
  *  Functors used to provide number returning functions to shape drawing routines 
  */
-export type Functor = () => number
+export type Functor = (datum: CandlestickData, index?: number) => number
 
 /**
  *  Parameter type to be provided to shapes, such as candlestick width
@@ -55,9 +55,11 @@ export interface Candlestick {
     low(value: FunctorParameter) : Candlestick;
     close(value: FunctorParameter) : Candlestick;
     width(value: FunctorParameter) : Candlestick;
+
+    (data: CandlestickData[]): void;
 }
 
 /**
  * Creates a candlestick
  */
-export const Candlestick: (data: CandlestickData) => Candlestick;
+export const Candlestick: (data?: CandlestickData) => Candlestick;

--- a/packages/d3fc-shape/src/index.d.ts
+++ b/packages/d3fc-shape/src/index.d.ts
@@ -1,0 +1,63 @@
+/**
+ * Type definitions for @d3fc/d3fc-shape v5.0.8
+ * 
+ * Definitions by: Hanna Greaves <https://github.com/hanna-greaves>
+ * Typescript version 3.5
+ */
+
+/**
+ *  Functors used to provide number returning functions to shape drawing routines 
+ */
+export type Functor = () => number
+
+/**
+ *  Parameter type to be provided to shapes, such as candlestick width
+ */
+export type FunctorParameter = number | Functor
+
+/**
+ * Data required to render a single candlestick chart
+ * 
+ * ToDo: Are these really optional pieces of data?
+ */
+export interface CandlestickData {
+    /** The X Location of the candlestick  */
+    x?: number
+
+    /** The open value of the real body */
+    open?: number
+
+    /** The close value of the real body */
+    close?: number
+
+    /** The top of the upper shadow */
+    high?: number
+
+    /** The bottom of the lower shadow */
+    low?: number
+
+    /** The width in pixels of the chart */
+    width?: number
+}
+
+/**
+ * A candlestick chart datapoint. Used to describe price movements of a security, derivative, or currency.
+ * 
+ * Operations performed on a candlestick return an updated candlestick
+ * 
+ * @see CandlestickData
+ */
+export interface Candlestick {
+    context(context: CanvasRenderingContext2D) : Candlestick;
+    x(value: FunctorParameter) : Candlestick;
+    open(value: FunctorParameter) : Candlestick;
+    high(value: FunctorParameter) : Candlestick;
+    low(value: FunctorParameter) : Candlestick;
+    close(value: FunctorParameter) : Candlestick;
+    width(value: FunctorParameter) : Candlestick;
+}
+
+/**
+ * Creates a candlestick
+ */
+export const Candlestick: (data: CandlestickData) => Candlestick;


### PR DESCRIPTION
Demonstration to get feedback on adding typescript definitions to d3fc. 

Naturally I would like to see us move this library to be written in native Typescript eventually but I am happy writing these definitions in the meantime ;) 

Here's a quick demo of the types being used in a `.ts` environment

![ts](https://user-images.githubusercontent.com/19157374/62614692-d1f44d80-b903-11e9-9828-b99b56431d26.gif)


