### PR TITLE
Run site script as part of travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ notifications:
   email: false
 node_js:
   - '10'
-
 script:
   - npm run bundle
-  - npm test 
-
+  - npm test
+  - cd packages/d3fc-site && npm run site
 before_install:
   - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 after_success:


### PR DESCRIPTION
*Hopefully* fixes #1300 - at the very least this change does need to be applied.

This line was removed from `d3fc-site/package.json` as part of merging #1295: `"test": "eslint src && npm run site",` which meant that `npm run site` was not run as part of the Travis build.