### PR TITLE
Switch travis site task to use lerna rather than cd into required package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 script:
   - npm run bundle
   - npm test
-  - cd packages/d3fc-site && npm run site
+  - npx lerna run --scope @d3fc/d3fc-site site
 before_install:
   - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 after_success:


### PR DESCRIPTION
Attempt two to fix #1300.

Previous attempt cd'd into d3fc-site which meant the next step failed. Instead, using lerna now to trigger the task in the d3fc-site package.