### PR TITLE
npm start from packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "puppeteer": "^1.19.0",
     "rollup": "^1.19.4",
     "rollup-plugin-babel": "^2.4.0",
+    "rollup-plugin-livereload": "^1.0.1",
     "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-serve": "^1.0.1",
     "serve-static": "^1.11.1",
     "uglify-js": "^2.6.2"
   }

--- a/packages/d3fc-annotation/package.json
+++ b/packages/d3fc-annotation/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": " npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js"

--- a/packages/d3fc-axis/package.json
+++ b/packages/d3fc-axis/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": "npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js"

--- a/packages/d3fc-brush/package.json
+++ b/packages/d3fc-brush/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": "npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js -- --selector #main-chart"

--- a/packages/d3fc-chart/package.json
+++ b/packages/d3fc-chart/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": "npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js -- --selector div"

--- a/packages/d3fc-element/package.json
+++ b/packages/d3fc-element/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": "npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js"

--- a/packages/d3fc-series/package.json
+++ b/packages/d3fc-series/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": "npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js"

--- a/packages/d3fc-technical-indicator/package.json
+++ b/packages/d3fc-technical-indicator/package.json
@@ -34,6 +34,7 @@
   },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "start": "npx rollup -c ../../scripts/rollup.config.js --environment BUILD:dev --watch",
     "test": "npx jasmine --config=../../scripts/jasmine.json",
     "lint": "npx eslint src/**/*.js",
     "screenshots": "node ../../scripts/screenshot.js"

--- a/packages/d3fc/package.json
+++ b/packages/d3fc/package.json
@@ -46,8 +46,6 @@
   },
   "devDependencies": {
     "babel-preset-es2015-rollup": "^3.0.0",
-    "rollup-plugin-livereload": "^1.0.1",
-    "rollup-plugin-progress": "^1.1.1",
-    "rollup-plugin-serve": "^1.0.1"
+    "rollup-plugin-progress": "^1.1.1"
   }
 }

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -1,7 +1,10 @@
 import babel from 'rollup-plugin-babel';
 import babelrc from 'babelrc-rollup';
 import nodeResolve from 'rollup-plugin-node-resolve';
+import serve from 'rollup-plugin-serve'
+import livereload from 'rollup-plugin-livereload'
 
+const devMode = process.env.BUILD === 'dev'
 var external = (key) => key.indexOf('d3-') === 0 || key.indexOf('d3fc-') === 0
 var globals = function(key) {
   if (key.indexOf('d3-') === 0) {
@@ -12,12 +15,27 @@ var globals = function(key) {
   }
 };
 
-let plugins = [
-  babel(babelrc()),
-  nodeResolve({ jsnext: true, main: true })
-];
-
 export default commandLineArgs => {
+    const page = commandLineArgs.openFile || 'index.html'
+    
+    let plugins = () => [
+      babel(babelrc()),
+      nodeResolve({ jsnext: true, main: true })
+    ];
+
+    const devPlugins = () => plugins().concat([
+      serve({
+          contentBase: ['..', '.'],
+          open: true,
+          openPage: `/examples/${page}`,
+          host: 'localhost',
+          port: 8080
+      }),
+      livereload({
+          watch: ['build', 'examples']
+      })
+    ]);
+
     const pkgInfo = require(`${process.cwd()}/package.json`)
     if(!pkgInfo) {
       throw Error('Expected build to be triggered from directory containing package.json')
@@ -27,9 +45,15 @@ export default commandLineArgs => {
       throw Error('Expected package.json to contain `name` field')
     }
     name = name.replace('@d3fc/', '')
+
+    if(devMode && !commandLineArgs.openFile) {
+      console.log('Did you know, you can specify an example to start using')
+      console.log('\x1b[30m\x1b[47m%s\x1b[0m', '\t-- --openFile="<example.html>" ?'); 
+    }
+
     return {
-      input: 'index.js',
-      plugins: plugins,
+      input: 'index.js', 
+      plugins: devMode ? devPlugins() : plugins(),
       external: external,
       output: {
           file: `build/${name}.js`,


### PR DESCRIPTION
You can now npm start from any package root with examples and optionally provide a -- --openFile='' flag to specify the example to use for dev mode.

E.g.

~~~
cd packages/d3fc-annotation
npm start -- --openFile='crosshair.html'
~~~