### PR TITLE
WIP: Line series for WebGL

### DIFF
--- a/packages/d3fc-series/examples/line.html
+++ b/packages/d3fc-series/examples/line.html
@@ -12,6 +12,7 @@
 <body>
     <svg id="line-svg" width="500" height="250"></svg>
     <canvas id="line-canvas"  width="500" height="250"></canvas>
+    <canvas id="line-webgl"  width="500" height="250"></canvas>
     <script src="line.js"></script>
 </body>
 </html>

--- a/packages/d3fc-series/examples/line.js
+++ b/packages/d3fc-series/examples/line.js
@@ -38,3 +38,18 @@ var canvasLine = fc.seriesCanvasLine()
     .crossValue(function(_, i) { return i; })
     .mainValue(function(d) { return d; });
 canvasLine(data);
+
+var canvasgl = d3.select('#line-webgl').node();
+canvasgl.width = width;
+canvasgl.height = height;
+var gl = canvasgl.getContext('webgl');
+
+var webglLine = fc.seriesWebglLine()
+    .xScale(xScale)
+    .yScale(yScale)
+    .defined((_, i) => i % 20 !== 0)
+    .context(gl)
+    .crossValue(function(_, i) { return i; })
+    .mainValue(function(d) { return d; });
+
+webglLine(data);

--- a/packages/d3fc-series/index.js
+++ b/packages/d3fc-series/index.js
@@ -1,5 +1,6 @@
 export { default as seriesSvgLine } from './src/svg/line';
 export { default as seriesCanvasLine } from './src/canvas/line';
+export { default as seriesWebglLine } from './src/webgl/line';
 
 export { default as seriesSvgPoint } from './src/svg/point';
 export { default as seriesCanvasPoint } from './src/canvas/point';

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -26,7 +26,6 @@ export default () => {
 
             draw.xValues(x)
                 .yValues(y)
-                .width(2)
                 .context(context)
                 .xScale(xScale.glScale)
                 .yScale(yScale.glScale)

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -1,0 +1,85 @@
+import xyBase from '../xyBase';
+import { glLine, scaleMapper } from '@d3fc/d3fc-webgl';
+import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
+
+export default () => {
+    const base = xyBase();
+    let context = null;
+
+    const line = (data) => {
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
+
+        const accessor = getAccessors();
+
+        const lines = getLines(data);
+        lines.forEach(l => {
+            const x = new Float32Array(l.length);
+            const y = new Float32Array(l.length);
+
+            l.forEach((dataPoint, i) => {
+                x[i] = xScale.scale(accessor.x(dataPoint.d, dataPoint.i));
+                y[i] = yScale.scale(accessor.y(dataPoint.d, dataPoint.i));
+            });
+
+            let draw = glLine();
+
+            draw.xValues(x)
+                .yValues(y)
+                .width(2)
+                .context(context)
+                .xScale(xScale.glScale)
+                .yScale(yScale.glScale)
+                .decorate((program) => base.decorate()(program, l.map(v => v.d), 0));
+
+            draw(l.length);
+        });
+    };
+
+    function getAccessors() {
+        if (base.orient() === 'vertical') {
+            return {
+                x: base.crossValue(),
+                y: base.mainValue()
+            };
+        } else {
+            return {
+                x: base.mainValue(),
+                y: base.crossValue()
+            };
+        }
+    }
+
+    // split the data into continuous segments of line
+    // they'll each be drawn individually
+    function getLines(data) {
+        const lines = [];
+
+        let currentLine = [];
+        data.forEach((d, i) => {
+            if (line.defined()(d, i)) {
+                currentLine.push({ d, i });
+            } else {
+                if (currentLine.length) {
+                    lines.push(currentLine);
+                    currentLine = [];
+                }
+            }
+        });
+        lines.push(currentLine);
+
+        return lines;
+    }
+
+    line.context = (...args) => {
+        if (!args.length) {
+            return context;
+        }
+        context = args[0];
+        return line;
+    };
+
+    rebindAll(line, base, exclude('baseValue', 'bandwidth', 'align'));
+
+    return line;
+}

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -6,6 +6,8 @@ export default () => {
     const base = xyBase();
     let context = null;
 
+    let draw = glLine();
+
     const line = (data) => {
         const xScale = scaleMapper(base.xScale());
         const yScale = scaleMapper(base.yScale());
@@ -21,8 +23,6 @@ export default () => {
                 x[i] = xScale.scale(accessor.x(dataPoint.d, dataPoint.i));
                 y[i] = yScale.scale(accessor.y(dataPoint.d, dataPoint.i));
             });
-
-            let draw = glLine();
 
             draw.xValues(x)
                 .yValues(y)
@@ -66,7 +66,9 @@ export default () => {
                 }
             }
         });
-        lines.push(currentLine);
+        if (currentLine.length) {
+            lines.push(currentLine);
+        }
 
         return lines;
     }

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -26,7 +26,6 @@ export default () => {
 
             draw.xValues(x)
                 .yValues(y)
-                .context(context)
                 .xScale(xScale.glScale)
                 .yScale(yScale.glScale)
                 .decorate((program) => base.decorate()(program, l.map(v => v.d), 0));
@@ -81,6 +80,7 @@ export default () => {
     };
 
     rebindAll(line, base, exclude('baseValue', 'bandwidth', 'align'));
+    rebind(line, draw, 'context');
 
     return line;
 }

--- a/packages/d3fc-webgl/examples/line.html
+++ b/packages/d3fc-webgl/examples/line.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <script src="../node_modules/d3/build/d3.js"></script>
+    <script src="../../d3fc-extent/build/d3fc-extent.js"></script>
+    <script src="../../d3fc-random-data/build/d3fc-random-data.js"></script>
+    <script src="../../d3fc-series/build/d3fc-series.js"></script>
+    <script src="../build/d3fc-webgl.js"></script>
+</head>
+<body id="body">
+    <canvas id="line-canvas"  width="500" height="250" style="position: absolute; top: 8px; left: 8px;"></canvas>
+    <canvas id="line-webgl"  width="500" height="250"></canvas>
+    <p id="fps">n/a</p>
+    <script src="line.js"></script>
+</body>
+</html>

--- a/packages/d3fc-webgl/examples/line.js
+++ b/packages/d3fc-webgl/examples/line.js
@@ -23,30 +23,6 @@ canvas.width = width;
 canvas.height = height;
 var ctx = canvas.getContext('webgl');
 
-// var xValues = new Float32Array(data.length);
-// var yValues = new Float32Array(data.length);
-
-// data.map((d, i) => {
-//     xValues[i] = i;
-//     yValues[i] = d;
-// });
-
-// var line = fc.glLine();
-
-const lineWidth = 16;
-
-// line.context(ctx)
-//     .xValues(xValues)
-//     .yValues(yValues)
-//     .width(lineWidth)
-//     .xScale(xScale.glScale)
-//     .yScale(yScale.glScale)
-//     .decorate(program => {
-//         fc.circleFill().color([0, 0, 1, 1])(program);
-//     });
-
-// line(data.length);
-
 var line = fc.seriesWebglLine()
     .xScale(d3XScale)
     .yScale(d3YScale)
@@ -55,19 +31,3 @@ var line = fc.seriesWebglLine()
     .mainValue(function(d) { return d; });
 
 line(data);
-
-var canvas2 = d3.select('#line-canvas').node();
-canvas2.width = width;
-canvas2.height = height;
-var ctx2 = canvas2.getContext('2d');
-
-var canvasLine = fc.seriesCanvasLine()
-    .xScale(d3XScale)
-    .yScale(d3YScale)
-    .context(ctx2)
-    .crossValue(function(_, i) { return i; })
-    .mainValue(function(d) { return d; })
-    .decorate((ctx, d) => {
-        ctx.lineWidth = lineWidth / 2; ctx.strokeStyle = '#ff0000'; ctx.globalAlpha = 0.5;
-    });
-canvasLine(data);

--- a/packages/d3fc-webgl/examples/line.js
+++ b/packages/d3fc-webgl/examples/line.js
@@ -1,0 +1,73 @@
+var width = 1600;
+var height = 800;
+
+const nSteps = 250;
+
+var dataGenerator = fc.randomGeometricBrownianMotion()
+  .steps(nSteps);
+var data = dataGenerator(10);
+
+var d3XScale = d3.scaleLinear()
+    .domain([0, nSteps])
+    .range([0, width]);
+
+var d3YScale = d3.scaleLinear()
+    .domain([fc.extentLinear()(data)[0], fc.extentLinear()(data)[1]])
+    .range([height, 0]);
+
+var xScale = fc.scaleMapper(d3XScale);
+var yScale = fc.scaleMapper(d3YScale);
+
+var canvas = d3.select('#line-webgl').node();
+canvas.width = width;
+canvas.height = height;
+var ctx = canvas.getContext('webgl');
+
+// var xValues = new Float32Array(data.length);
+// var yValues = new Float32Array(data.length);
+
+// data.map((d, i) => {
+//     xValues[i] = i;
+//     yValues[i] = d;
+// });
+
+// var line = fc.glLine();
+
+const lineWidth = 16;
+
+// line.context(ctx)
+//     .xValues(xValues)
+//     .yValues(yValues)
+//     .width(lineWidth)
+//     .xScale(xScale.glScale)
+//     .yScale(yScale.glScale)
+//     .decorate(program => {
+//         fc.circleFill().color([0, 0, 1, 1])(program);
+//     });
+
+// line(data.length);
+
+var line = fc.seriesWebglLine()
+    .xScale(d3XScale)
+    .yScale(d3YScale)
+    .context(ctx)
+    .crossValue(function(_, i) { return i; })
+    .mainValue(function(d) { return d; });
+
+line(data);
+
+var canvas2 = d3.select('#line-canvas').node();
+canvas2.width = width;
+canvas2.height = height;
+var ctx2 = canvas2.getContext('2d');
+
+var canvasLine = fc.seriesCanvasLine()
+    .xScale(d3XScale)
+    .yScale(d3YScale)
+    .context(ctx2)
+    .crossValue(function(_, i) { return i; })
+    .mainValue(function(d) { return d; })
+    .decorate((ctx, d) => {
+        ctx.lineWidth = lineWidth / 2; ctx.strokeStyle = '#ff0000'; ctx.globalAlpha = 0.5;
+    });
+canvasLine(data);

--- a/packages/d3fc-webgl/index.js
+++ b/packages/d3fc-webgl/index.js
@@ -9,6 +9,7 @@ export { default as circlePointShader } from './src/shaders/point/circle/baseSha
 export { default as circleFill } from './src/shaders/point/circle/fill';
 export { default as circleStroke } from './src/shaders/point/circle/stroke';
 export { default as circleAntiAlias } from './src/shaders/point/circle/antiAlias';
+export { default as lineWidth } from './src/shaders/line/width';
 
 export { default as glPoint } from './src/series/glPoint';
 export { default as glLine } from './src/series/glLine';

--- a/packages/d3fc-webgl/index.js
+++ b/packages/d3fc-webgl/index.js
@@ -11,6 +11,7 @@ export { default as circleStroke } from './src/shaders/point/circle/stroke';
 export { default as circleAntiAlias } from './src/shaders/point/circle/antiAlias';
 
 export { default as glPoint } from './src/series/glPoint';
+export { default as glLine } from './src/series/glLine';
 
 export { default as glScaleLinear } from './src/scale/glScaleLinear';
 export { default as glScaleLog } from './src/scale/glScaleLog';

--- a/packages/d3fc-webgl/src/buffers/attributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/attributeBuilder.js
@@ -23,7 +23,9 @@ export default (_data) => {
 
         const dataType = getGLType(data.constructor, gl);
 
-        buffer = buffer && gl.isBuffer(buffer) ? buffer : gl.createBuffer();
+        // if we already have a buffer, use it
+        // if the WebGL context is switched out, programBuilder recreates the bufferBuilder
+        buffer = buffer || gl.createBuffer();
 
         const location = gl.getAttribLocation(program, name);
         gl.bindBuffer(gl.ARRAY_BUFFER, buffer);

--- a/packages/d3fc-webgl/src/buffers/attributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/attributeBuilder.js
@@ -23,8 +23,6 @@ export default (_data) => {
 
         const dataType = getGLType(data.constructor, gl);
 
-        // if we already have a buffer, use it
-        // if the WebGL context is switched out, programBuilder recreates the bufferBuilder
         buffer = buffer || gl.createBuffer();
 
         const location = gl.getAttribLocation(program, name);

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -27,10 +27,6 @@ export default () => {
         if (!args.length) {
             return context;
         }
-        // if we have switched context the buffers are invalid - create new buffers
-        if (args[0] !== context) {
-            buffers = bufferBuilder();
-        }
         context = args[0];
         return build;
     };

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -8,8 +8,7 @@ export default () => {
     let fragmentShader = null;
     let mode = drawModes.TRIANGLES;
     let buffers = bufferBuilder();
-
-    const build = (numElements) => {
+    const build = (numElements, start = 0, bufferSize = numElements) => {
         const vertexShaderSource = vertexShader();
         const fragmentShaderSource = fragmentShader();
         if (newProgram(program, vertexShaderSource, fragmentShaderSource)) {
@@ -18,9 +17,9 @@ export default () => {
         }
         context.useProgram(program);
 
-        buffers(context, program, numElements);
+        buffers(context, program, bufferSize);
 
-        context.drawArrays(mode, 0, numElements);
+        context.drawArrays(mode, start, numElements);
     };
 
     build.context = (...args) => {
@@ -66,7 +65,7 @@ export default () => {
     return build;
 
     function newProgram(program, vertexShader, fragmentShader) {
-        if (!context.isProgram(program)) {
+        if (!program) {
             return true;
         }
 

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -27,6 +27,10 @@ export default () => {
         if (!args.length) {
             return context;
         }
+        // if we have switched context the buffers are invalid - create new buffers
+        if (args[0] !== context) {
+            buffers = bufferBuilder();
+        }
         context = args[0];
         return build;
     };

--- a/packages/d3fc-webgl/src/scale/glScaleLinear.js
+++ b/packages/d3fc-webgl/src/scale/glScaleLinear.js
@@ -32,10 +32,15 @@ export default () => {
             .appendHeader(`uniform vec4 ${prefix()}Offset;`)
             .appendHeader(`uniform vec4 ${prefix()}Scale;`);
 
-        program.vertexShader()
-            .appendBody(`gl_Position = gl_Position + ${prefix()}Offset;`)
-            .appendBody(`gl_Position = gl_Position * ${prefix()}Scale;`);
+        apply.scaleComponent(program, 'gl_Position');
     }
+
+    apply.scaleComponent = (program, component) => {
+        program.vertexShader()
+            .appendBody(`${component} = ${component} + ${prefix()}Offset;`)
+            .appendBody(`${component} = ${component} * ${prefix()}Scale;`);
+        return apply;
+    };
 
     rebindAll(apply, base);
 

--- a/packages/d3fc-webgl/src/scale/glScaleLog.js
+++ b/packages/d3fc-webgl/src/scale/glScaleLog.js
@@ -42,12 +42,16 @@ export default () => {
             .appendHeader(`uniform vec4 ${prefix()}Scale;`)
             .appendHeader(`uniform vec4 ${prefix()}Include;`)
             .appendHeader(`uniform float ${prefix()}Base;`);
+        apply.scaleComponent(program, 'gl_Position');
+    }
 
-        const logPart = `${prefix()}Offset + (${prefix()}Scale * clamp(log(gl_Position) / log(${prefix()}Base), -inf, inf))`;
+    apply.scaleComponent = (program, component) => {
+        const logPart = `${prefix()}Offset + (${prefix()}Scale * clamp(log(${component}) / log(${prefix()}Base), -inf, inf))`;
 
         program.vertexShader()
-            .appendBody(`gl_Position = (${prefix()}Include * (${logPart})) + ((1.0 - ${prefix()}Include) * gl_Position);`);
-    }
+            .appendBody(`${component} = (${prefix()}Include * (${logPart})) + ((1.0 - ${prefix()}Include) * ${component});`);
+        return apply;
+    };
 
     apply.base = (...args) => {
         if (!args.length) {

--- a/packages/d3fc-webgl/src/scale/glScalePow.js
+++ b/packages/d3fc-webgl/src/scale/glScalePow.js
@@ -43,11 +43,16 @@ export default () => {
             .appendHeader(`uniform vec4 ${prefix()}Include;`)
             .appendHeader(`uniform float ${prefix()}Exp;`);
 
-        const powPart = `${prefix()}Offset + (${prefix()}Scale * sign(gl_Position) * pow(abs(gl_Position), vec4(${prefix()}Exp)))`;
+        apply.scaleComponent(program, 'gl_Position');
+    }
+
+    apply.scaleComponent = (program, component) => {
+        const powPart = `${prefix()}Offset + (${prefix()}Scale * sign(${component}) * pow(abs(gl_Position), vec4(${prefix()}Exp)))`;
 
         program.vertexShader()
-            .appendBody(`gl_Position = (${prefix()}Include * (${powPart})) + ((1.0 - ${prefix()}Include) * gl_Position);`);
-    }
+            .appendBody(`${component} = (${prefix()}Include * (${powPart})) + ((1.0 - ${prefix()}Include) * ${component});`);
+        return apply;
+    };
 
     apply.exponent = (...args) => {
         if (!args.length) {

--- a/packages/d3fc-webgl/src/series/glLine.js
+++ b/packages/d3fc-webgl/src/series/glLine.js
@@ -1,0 +1,161 @@
+import attributeBuilder from '../buffers/attributeBuilder';
+import glScaleBase from '../scale/glScaleBase';
+import programBuilder from '../program/programBuilder';
+import lineShader from '../shaders/line/baseShader';
+import drawModes from '../program/drawModes';
+import { rebind } from '@d3fc/d3fc-rebind';
+import uniformBuilder from '../buffers/uniformBuilder';
+
+export default () => {
+    let program = programBuilder();
+    let xScale = glScaleBase();
+    let yScale = glScaleBase();
+    let decorate = () => {};
+
+    const xValueAttrib = 'aXValue';
+    const yValueAttrib = 'aYValue';
+    const xNextValueAttrib = 'aNextXValue';
+    const yNextValueAttrib = 'aNextYValue';
+    const xPrevValueAttrib = 'aPrevXValue';
+    const yPrevValueAttrib = 'aPrevYValue';
+    const invValueAttrib = 'aSide';
+    const widthUniform = 'uWidth';
+    const screenUniform = 'uScreen';
+
+    const draw = (numElements) => {
+        // we are resetting the shader each draw here, to avoid issues with decorate
+        // we'll eventually need a way to change the symbol type here
+        const shaderBuilder = lineShader();
+        program.vertexShader(shaderBuilder.vertex())
+               .fragmentShader(shaderBuilder.fragment())
+               .mode(drawModes.TRIANGLE_STRIP);
+
+        // apply the scale to our current, next and previous coordinates
+        xScale.coordinate(0);
+        xScale(program);
+        yScale.coordinate(1);
+        yScale(program);
+        xScale.scaleComponent(program, 'next');
+        yScale.scaleComponent(program, 'next');
+        xScale.scaleComponent(program, 'prev');
+        yScale.scaleComponent(program, 'prev');
+
+        // from here we are dealing with pre-scaled vertex positions
+        program.vertexShader()
+            .appendBody(`if (all(equal(gl_Position.xy, prev.xy))) {
+                prev.xy = gl_Position.xy + normalize(gl_Position.xy - next.xy);
+            }`)
+            .appendBody(`if (all(equal(gl_Position.xy, next.xy))) {
+                next.xy = gl_Position.xy + normalize(gl_Position.xy - prev.xy);
+            }`)
+            .appendBody(`vec2 A = normalize(normalize(gl_Position.xy - prev.xy) * uScreen);`)
+            .appendBody(`vec2 B = normalize(normalize(next.xy - gl_Position.xy) * uScreen);`)
+            .appendBody(`vec2 tangent = normalize(A + B);`)
+            .appendBody(`vec2 miter = vec2(-tangent.y, tangent.x);`)
+            .appendBody(`vec2 normalA = vec2(-A.y, A.x);`)
+            .appendBody(`float miterLength = (1.0 / 2.0) / dot(miter, normalA);`)
+            .appendBody(`gl_Position.xy = gl_Position.xy + (aSide * (miter * uWidth * miterLength)) / uScreen.xy;`);
+
+        program.buffers().uniform(screenUniform, uniformBuilder([
+            program.context().canvas.width,
+            program.context().canvas.height
+        ]));
+
+        decorate(program);
+
+        program(numElements * 2);
+    };
+
+    draw.xValues = (...args) => {
+        const builder = program.buffers().attribute(xValueAttrib);
+        const next = program.buffers().attribute(xNextValueAttrib);
+        const prev = program.buffers().attribute(xPrevValueAttrib);
+        const inv = program.buffers().attribute(invValueAttrib);
+
+        let currArray = new Float32Array(args[0].length * 2);
+        currArray = currArray.map((d, i) => args[0][Math.floor(i / 2)]);
+        const nextArray = new Float32Array(currArray);
+        const prevArray = new Float32Array(currArray);
+        nextArray.copyWithin(0, 2);
+        prevArray.copyWithin(2, 0);
+
+        let invArray = new Float32Array(args[0].length * 2);
+        let invValue = -1;
+        invArray = invArray.map((d, i) => invValue = invValue * -1);
+
+        if (builder) {
+            builder.data(currArray);
+            next.data(nextArray);
+            prev.data(prevArray);
+            inv.data(invArray);
+        } else {
+            program.buffers().attribute(xValueAttrib, attributeBuilder(currArray).components(1));
+            program.buffers().attribute(xNextValueAttrib, attributeBuilder(nextArray).components(1));
+            program.buffers().attribute(xPrevValueAttrib, attributeBuilder(prevArray).components(1));
+            program.buffers().attribute(invValueAttrib, attributeBuilder(invArray).components(1));
+        }
+        return draw;
+    };
+
+    draw.yValues = (...args) => {
+        const builder = program.buffers().attribute(yValueAttrib);
+        const next = program.buffers().attribute(yNextValueAttrib);
+        const prev = program.buffers().attribute(yPrevValueAttrib);
+
+        let currArray = new Float32Array(args[0].length * 2);
+        currArray = currArray.map((d, i) => args[0][Math.floor(i / 2)]);
+        const nextArray = new Float32Array(currArray);
+        const prevArray = new Float32Array(currArray);
+        nextArray.copyWithin(0, 2);
+        prevArray.copyWithin(2, 0);
+
+        if (builder) {
+            builder.data(currArray);
+            next.data(nextArray);
+            prev.data(prevArray);
+        } else {
+            program.buffers().attribute(yValueAttrib, attributeBuilder(currArray).components(1));
+            program.buffers().attribute(yNextValueAttrib, attributeBuilder(nextArray).components(1));
+            program.buffers().attribute(yPrevValueAttrib, attributeBuilder(prevArray).components(1));
+        }
+        return draw;
+    };
+
+    draw.width = (...args) => {
+        const builder = program.buffers().uniform(widthUniform);
+        if (builder) {
+            builder.data(args[0]);
+        } else {
+            program.buffers().uniform(widthUniform, uniformBuilder(args[0]));
+        }
+        return draw;
+    }
+
+    draw.decorate = (...args) => {
+        if (!args.length) {
+            return decorate;
+        }
+        decorate = args[0];
+        return draw;
+    };
+
+    draw.xScale = (...args) => {
+        if (!args.length) {
+            return xScale;
+        }
+        xScale = args[0];
+        return draw;
+    };
+
+    draw.yScale = (...args) => {
+        if (!args.length) {
+            return yScale;
+        }
+        yScale = args[0];
+        return draw;
+    };
+
+    rebind(draw, program, 'context');
+
+    return draw;
+};

--- a/packages/d3fc-webgl/src/series/glLine.js
+++ b/packages/d3fc-webgl/src/series/glLine.js
@@ -5,6 +5,7 @@ import lineShader from '../shaders/line/baseShader';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
 import uniformBuilder from '../buffers/uniformBuilder';
+import width from '../shaders/line/width';
 
 export default () => {
     let program = programBuilder();
@@ -53,13 +54,15 @@ export default () => {
             .appendBody(`vec2 tangent = normalize(A + B);`)
             .appendBody(`vec2 miter = vec2(-tangent.y, tangent.x);`)
             .appendBody(`vec2 normalA = vec2(-A.y, A.x);`)
-            .appendBody(`float miterLength = (1.0 / 2.0) / dot(miter, normalA);`)
+            .appendBody(`float miterLength = 1.0 / dot(miter, normalA);`)
             .appendBody(`gl_Position.xy = gl_Position.xy + (aSide * (miter * uWidth * miterLength)) / uScreen.xy;`);
 
         program.buffers().uniform(screenUniform, uniformBuilder([
             program.context().canvas.width,
             program.context().canvas.height
         ]));
+
+        width()(program);
 
         decorate(program);
 

--- a/packages/d3fc-webgl/src/shaders/line/baseShader.js
+++ b/packages/d3fc-webgl/src/shaders/line/baseShader.js
@@ -1,6 +1,4 @@
 import shaderBuilder, { vertexShaderBase, fragmentShaderBase } from '../shaderBuilder';
-import * as vertexShaderSnippets from '../vertexShaderSnippets';
-import * as fragmentShaderSnippets from '../fragmentShaderSnippets';
 
 export default () => {
     const vertexShader = shaderBuilder(vertexShaderBase);

--- a/packages/d3fc-webgl/src/shaders/line/baseShader.js
+++ b/packages/d3fc-webgl/src/shaders/line/baseShader.js
@@ -1,0 +1,25 @@
+import shaderBuilder, { vertexShaderBase, fragmentShaderBase } from '../shaderBuilder';
+import * as vertexShaderSnippets from '../vertexShaderSnippets';
+import * as fragmentShaderSnippets from '../fragmentShaderSnippets';
+
+export default () => {
+    const vertexShader = shaderBuilder(vertexShaderBase);
+    const fragmentShader = shaderBuilder(fragmentShaderBase);
+
+    vertexShader
+        .appendHeader(`uniform float uWidth;`) // defines the width of the line
+        .appendHeader(`uniform vec2 uScreen;`) // the screen space canvas size (for normalizing vectors)
+        .appendHeader(`attribute float aSide;`) // defines which side of the line we are placing the vertex
+        .appendHeader(`attribute float aXValue; attribute float aYValue;`) // the current vertex positions
+        .appendHeader(`attribute float aNextXValue; attribute float aNextYValue;`) // the next vertex positions
+        .appendHeader(`attribute float aPrevXValue; attribute float aPrevYValue;`) // the previous vertex positions
+        .appendBody(`vec4 curr = vec4(aXValue, aYValue, 0, 1);`)
+        .appendBody(`gl_Position = curr;`)
+        .appendBody(`vec4 next = vec4(aNextXValue, aNextYValue, 0, 0);`)
+        .appendBody(`vec4 prev = vec4(aPrevXValue, aPrevYValue, 0, 0);`);
+
+    return {
+        vertex: () => vertexShader,
+        fragment: () => fragmentShader
+    };
+};

--- a/packages/d3fc-webgl/src/shaders/line/baseShader.js
+++ b/packages/d3fc-webgl/src/shaders/line/baseShader.js
@@ -7,7 +7,7 @@ export default () => {
     vertexShader
         .appendHeader(`uniform float uWidth;`) // defines the width of the line
         .appendHeader(`uniform vec2 uScreen;`) // the screen space canvas size (for normalizing vectors)
-        .appendHeader(`attribute float aSide;`) // defines which side of the line we are placing the vertex
+        .appendHeader(`attribute vec2 aCorner;`) // defines which vertex in the line join we are considering
         .appendHeader(`attribute float aXValue; attribute float aYValue;`) // the current vertex positions
         .appendHeader(`attribute float aNextXValue; attribute float aNextYValue;`) // the next vertex positions
         .appendHeader(`attribute float aPrevXValue; attribute float aPrevYValue;`) // the previous vertex positions

--- a/packages/d3fc-webgl/src/shaders/line/width.js
+++ b/packages/d3fc-webgl/src/shaders/line/width.js
@@ -1,0 +1,19 @@
+import uniformBuilder from "../../buffers/uniformBuilder";
+
+export default () => {
+    let width = 1;
+
+    const lineWidth = (program) => {
+        program.buffers().uniform('uWidth', uniformBuilder(width));
+    };
+
+    lineWidth.width = (...args) => {
+        if (!args.length) {
+            return width;
+        }
+        width = args[0];
+        return lineWidth;
+    };
+
+    return lineWidth;
+};


### PR DESCRIPTION
This adds a line series alongside the existing point series.

It currently supports drawing lines, with breaks in the series, and matches the linear curve type in SVG and canvas.
It doesn't support curve types other than linear (we're not even checking, just linear by default).

It also could do with a bit of cleaning around the shader code doing the line joins at each vertex.