### PR TITLE
feat: support latest d3-scale and d3-chromatic-scale in d3fc-series

### DIFF
--- a/packages/d3fc-series/package-lock.json
+++ b/packages/d3fc-series/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@d3fc/d3fc-series",
-	"version": "4.0.28",
+	"version": "4.0.29",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -93,6 +93,21 @@
 					"integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q=",
 					"dev": true
 				},
+				"d3-scale": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+					"integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+					"dev": true,
+					"requires": {
+						"d3-array": "^1.2.0",
+						"d3-collection": "1",
+						"d3-color": "1",
+						"d3-format": "1",
+						"d3-interpolate": "1",
+						"d3-time": "1",
+						"d3-time-format": "2"
+					}
+				},
 				"d3-selection": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
@@ -126,9 +141,9 @@
 			}
 		},
 		"d3-array": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-			"integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.3.2.tgz",
+			"integrity": "sha512-cg73UOh7D7e72FQQER4l5aXnEwlizah8TIggMn8qtEO/7APe5s6bAZhlDlVw0BRml6Qi4bd44WJ5HGuiK7fRyw=="
 		},
 		"d3-axis": {
 			"version": "1.0.8",
@@ -157,12 +172,21 @@
 			"requires": {
 				"d3-array": "1",
 				"d3-path": "1"
+			},
+			"dependencies": {
+				"d3-array": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+					"integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+					"dev": true
+				}
 			}
 		},
 		"d3-collection": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-			"integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+			"integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+			"dev": true
 		},
 		"d3-color": {
 			"version": "1.3.0",
@@ -215,9 +239,9 @@
 			}
 		},
 		"d3-format": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
-			"integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.1.tgz",
+			"integrity": "sha512-TUswGe6hfguUX1CtKxyG2nymO+1lyThbkS1ifLX0Sr+dOQtAD5gkrffpHnx+yHNKUZ0Bmg5T4AjUQwugPDrm0g=="
 		},
 		"d3-geo": {
 			"version": "1.9.1",
@@ -226,6 +250,14 @@
 			"dev": true,
 			"requires": {
 				"d3-array": "1"
+			},
+			"dependencies": {
+				"d3-array": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+					"integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+					"dev": true
+				}
 			}
 		},
 		"d3-hierarchy": {
@@ -284,17 +316,24 @@
 			}
 		},
 		"d3-scale": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-			"integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.1.0.tgz",
+			"integrity": "sha512-3edyEBwbwQG400VbgaepQC9ZYFX3h92flLHIUa1+nvZp/mqCYdxNM9zGTjKtPcSAuBCyPePdMQOapsD0qNALrg==",
 			"requires": {
-				"d3-array": "^1.2.0",
-				"d3-collection": "1",
-				"d3-color": "1",
+				"d3-array": "1.2.0 - 2",
 				"d3-format": "1",
 				"d3-interpolate": "1",
 				"d3-time": "1",
 				"d3-time-format": "2"
+			}
+		},
+		"d3-scale-chromatic": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+			"integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+			"requires": {
+				"d3-color": "1",
+				"d3-interpolate": "1"
 			}
 		},
 		"d3-selection": {
@@ -311,9 +350,9 @@
 			}
 		},
 		"d3-time": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
-			"integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+			"integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
 		},
 		"d3-time-format": {
 			"version": "2.1.3",

--- a/packages/d3fc-series/package.json
+++ b/packages/d3fc-series/package.json
@@ -33,8 +33,9 @@
     "@d3fc/d3fc-data-join": "^5.0.10",
     "@d3fc/d3fc-rebind": "^5.0.9",
     "@d3fc/d3fc-shape": "^5.0.18",
-    "d3-array": "^1.0.0",
-    "d3-scale": "^1.0.1",
+    "d3-array": "^2.3.2",
+    "d3-scale": "^3.1.0",
+    "d3-scale-chromatic": "^1.5.0",
     "d3-selection": "^1.0.0",
     "d3-shape": "^1.0.0"
   },

--- a/packages/d3fc-series/src/heatmapBase.js
+++ b/packages/d3fc-series/src/heatmapBase.js
@@ -1,4 +1,5 @@
-import { scaleIdentity, interpolateViridis, scaleLinear } from 'd3-scale';
+import { scaleIdentity, scaleLinear } from 'd3-scale';
+import { interpolateViridis } from 'd3-scale-chromatic';
 import { min, max } from 'd3-array';
 import { rebindAll, includeMap, rebind } from '@d3fc/d3fc-rebind';
 import { shapeBar } from '@d3fc/d3fc-shape';


### PR DESCRIPTION
When using d3fc-series in combination with d3fc-discontinuous-scale, CI builds keep failing. 
It looks like d3fc-series resolves the d3-scale dependency by using the same version as d3fc-discontinuous-scale, which is higher and does not support the same API.

This commit is about upgrading the d3fc-series dependencies to latest versions.

I am not familiar with building d3fc, what I can assert is I could successfully run install, bundle and test, from the d3fc root folder, both before and after the change.

Please let me know if there is anything else I can do to make sure this test will not break other code.

Also, this change will need a version bump, let me know if it need to be committed as part of the PR.