### PR TITLE
Added `skipUTCWeekends.js` to `d3fc-discontinuous-scale`.

### DIFF
--- a/packages/d3fc-discontinuous-scale/README.md
+++ b/packages/d3fc-discontinuous-scale/README.md
@@ -112,6 +112,7 @@ const range = discontinuityRange([start, end]);
 ### discontinuitySkipWeekends
 
 <a name="discontinuitySkipWeekends" href="#discontinuitySkipWeekends">#</a> fc.**discontinuitySkipWeekends**()
+<a name="discontinuitySkipUtcWeekends" href="#discontinuitySkipUtcWeekends">#</a> fc.**discontinuitySkipUtcWeekends**()
 
 This discontinuity provider is intended to be used with a time scale. This provider will remove all weekends from the domain, a feature which is particularly useful for financial time-series charts.
 

--- a/packages/d3fc-discontinuous-scale/index.js
+++ b/packages/d3fc-discontinuous-scale/index.js
@@ -1,5 +1,6 @@
 export { default as scaleDiscontinuous } from './src/discontinuous';
 
 export { default as discontinuitySkipWeekends } from './src/discontinuity/skipWeekends';
+export { default as discontinuitySkipUtcWeekends } from './src/discontinuity/skipUtcWeekends';
 export { default as discontinuityIdentity } from './src/discontinuity/identity';
 export { default as discontinuityRange } from './src/discontinuity/range';

--- a/packages/d3fc-discontinuous-scale/src/discontinuity/skipUtcWeekends.js
+++ b/packages/d3fc-discontinuous-scale/src/discontinuity/skipUtcWeekends.js
@@ -1,0 +1,4 @@
+import { utcDay, utcSaturday, utcMonday } from 'd3-time';
+import { base } from './skipWeekends';
+
+export default () => base(date => date.getUTCDay(), utcDay, utcSaturday, utcMonday);

--- a/packages/d3fc-discontinuous-scale/test/discontinuity/skipUtcWeekendsSpec.js
+++ b/packages/d3fc-discontinuous-scale/test/discontinuity/skipUtcWeekendsSpec.js
@@ -1,0 +1,94 @@
+import skipUTCWeekends from '../../src/discontinuity/skipUtcWeekends';
+import {utcDay, utcMillisecond, utcMinute} from 'd3-time';
+
+describe('skipUTCWeekends', () => {
+    const millisPerDay = 24 * 3600 * 1000;
+    const wednesday = new Date(Date.UTC(2016, 0, 6));
+
+    // this is 00:00:00 hours on monday, which is at the very start of the week
+    const mondayBoundary = new Date(Date.UTC(2016, 0, 4));
+    // this is 00:00:00 hours on Saturday, which is at the very start of the weekend
+    const saturdayBoundary = new Date(Date.UTC(2016, 0, 2));
+
+    describe('clampUp', () => {
+        it('should do nothing if provided with a weekday', () => {
+            expect(skipUTCWeekends().clampUp(wednesday)).toEqual(wednesday);
+        });
+
+        it('should clamp up if given a weekend', () => {
+            // try subtracting a millisecond
+            expect(skipUTCWeekends().clampUp(utcMillisecond.offset(mondayBoundary, -1)))
+              .toEqual(mondayBoundary);
+
+            // try subtracting a minute
+            expect(skipUTCWeekends().clampUp(utcMinute.offset(mondayBoundary, -1)))
+              .toEqual(mondayBoundary);
+
+            // try subtracting a day
+            expect(skipUTCWeekends().clampUp(utcDay.offset(mondayBoundary, -1)))
+              .toEqual(mondayBoundary);
+
+            // try subtracting one and a half days
+            expect(skipUTCWeekends().clampUp(utcDay.offset(mondayBoundary, -1.5)))
+              .toEqual(mondayBoundary);
+        });
+
+        it('should not clamp up at the boundary of a discontinuity', () => {
+            // clamping the boundary should return the bundary
+            expect(skipUTCWeekends().clampUp(mondayBoundary))
+              .toEqual(mondayBoundary);
+
+            // by subtracting one day and one millisecond, this will fall just outside of the weekend, so should not be clamped
+            const friday = utcMillisecond.offset(utcDay.offset(mondayBoundary, -2), -1);
+            expect(skipUTCWeekends().clampUp(friday))
+              .toEqual(friday);
+        });
+    });
+
+    describe('clampDown', () => {
+        it('should do nothing if provided with a weekday', () => {
+            expect(skipUTCWeekends().clampDown(wednesday)).toEqual(wednesday);
+        });
+
+        it('should clamp down if given a weekend', () => {
+            // clamping the boundary should return the bundary
+            expect(skipUTCWeekends().clampDown(saturdayBoundary))
+              .toEqual(saturdayBoundary);
+
+            // try adding a millisecond
+            expect(skipUTCWeekends().clampDown(utcMillisecond.offset(saturdayBoundary, 1)))
+              .toEqual(saturdayBoundary);
+
+            // try adding a minute
+            expect(skipUTCWeekends().clampDown(utcMinute.offset(saturdayBoundary, 1)))
+              .toEqual(saturdayBoundary);
+
+            // try adding a day
+            expect(skipUTCWeekends().clampDown(utcDay.offset(saturdayBoundary, 1)))
+              .toEqual(saturdayBoundary);
+
+            // try adding one and a half days
+            expect(skipUTCWeekends().clampDown(utcDay.offset(saturdayBoundary, 1.5)))
+              .toEqual(saturdayBoundary);
+
+        });
+
+        it('should not clamp down at the boundary of a discontinuity', () => {
+            // by adding two days, this will fall just outside of the weekend, so should not be clamped
+            const monday = utcDay.offset(saturdayBoundary, 2);
+            expect(skipUTCWeekends().clampDown(monday))
+              .toEqual(monday);
+
+            // by subtracting one millisecond, this will fall just outside of the weekend, so should not be clamped
+            const friday = utcMillisecond.offset(saturdayBoundary, -1);
+            expect(skipUTCWeekends().clampDown(friday))
+              .toEqual(friday);
+        });
+    });
+
+    it('should remove weekends', () => {
+        expect(skipUTCWeekends().distance(mondayBoundary, wednesday)).toEqual(2 * millisPerDay);
+        expect(skipUTCWeekends().distance(mondayBoundary, utcDay.offset(mondayBoundary, 7)))
+            .toEqual(5 * millisPerDay);
+    });
+});


### PR DESCRIPTION
Hi there, thanks for creating `d3fc-discontinuous-scale`.

I struggled when I was using the `skipWeekends` discontinuity provider because it works with the non-UTC date API, so I copied the file and replaced the date API calls with their UTC counterparts.

Hopefully I didn't break more stuff than what I fixed.