### PR TITLE
fix: changes uniform to attribute for multicolor

### DIFF
--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -9,9 +9,9 @@ export const translate = {
 };
 
 export const multiColor = {
-    header: `uniform vec4 uColor;
+    header: `attribute vec4 aColor;
              varying vec4 vColor;`,
-    body: `vColor = uColor;`
+    body: `vColor = aColor;`
 };
 
 export const circle = {


### PR DESCRIPTION
Changes variable in `multiColor` from `uniform` to `attribute` so that multiple colours can be set, currently this behaves the same as `seriesColor`