### PR TITLE
fix: updated webgl examples to match refactored api

### DIFF
--- a/packages/d3fc-webgl/examples/candlestick.js
+++ b/packages/d3fc-webgl/examples/candlestick.js
@@ -14,7 +14,7 @@ const getWebglSeries = () =>
     fc
         .seriesWebglCandlestick()
         .bandwidth(10)
-        .width(2);
+        .lineWidth(2);
 
 const zoom = d3.zoom().on('zoom', () => {
     x.domain(d3.event.transform.rescaleX(x2).domain());

--- a/packages/d3fc-webgl/examples/ohlc.js
+++ b/packages/d3fc-webgl/examples/ohlc.js
@@ -14,7 +14,7 @@ const getWebglSeries = () =>
     fc
         .seriesWebglOhlc()
         .bandwidth(10)
-        .width(2);
+        .lineWidth(2);
 
 const zoom = d3.zoom().on('zoom', () => {
     x.domain(d3.event.transform.rescaleX(x2).domain());


### PR DESCRIPTION
Updated `candlestick` and `ohlc` examples to use `lineWidth` instead of `width`.
Currently the examples throw errors and do not render anything.