### PR TITLE
feat: add elementConstantAttributeBuilder

### DIFF
--- a/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
@@ -1,0 +1,83 @@
+import baseAttributeBuilder from './baseAttributeBuilder';
+import { rebindAll, exclude } from '@d3fc/d3fc-rebind';
+
+export default () => {
+    const base = baseAttributeBuilder();
+
+    let value = (data, element, vertex, component, index) => data[element];
+    let data = null;
+    let validSize = 0;
+
+    const project = (elementCount, verticesPerElement) => {
+        const components = base.size();
+        const offset = base.offset();
+        const projectedData = new Float32Array(
+            offset + elementCount * verticesPerElement * components
+        );
+        let element = 0;
+        for (
+            let index = offset;
+            index <= projectedData.length;
+            index += verticesPerElement * components
+        ) {
+            projectedData.fill(
+                value(data, element),
+                index,
+                index + verticesPerElement * components
+            );
+            element++;
+        }
+        return projectedData;
+    };
+
+    const build = (gl, program, name, verticesPerElement, count) => {
+        if (validSize >= count) {
+            return;
+        }
+
+        base(gl, program, name);
+
+        if (typeof value === 'function') {
+            const projectedData = project(count, verticesPerElement);
+            gl.bindBuffer(gl.ARRAY_BUFFER, base.buffer());
+            gl.bufferData(gl.ARRAY_BUFFER, projectedData, gl.DYNAMIC_DRAW);
+        } else if (Array.isArray(value)) {
+            if (value.length === base.size()) {
+                const location = gl.getAttribLocation(program, name);
+                gl[`vertexAttrib${value.length}fv`](location, value);
+                gl.disableVertexAttribArray(location);
+            } else {
+                throw new Error(
+                    `Expected array of length: ${base.size()}, recieved array of length: ${
+                        value.length
+                    }`
+                );
+            }
+        } else {
+            throw new Error(`Expected function or array, received: ${value}`);
+        }
+        validSize = count;
+    };
+
+    build.value = (...args) => {
+        if (!args.length) {
+            return value;
+        }
+        value = args[0];
+        validSize = 0;
+        return build;
+    };
+
+    build.data = (...args) => {
+        if (!args.length) {
+            return data;
+        }
+        data = args[0];
+        validSize = 0;
+        return build;
+    };
+
+    rebindAll(build, base, exclude('buffer'));
+
+    return build;
+};

--- a/packages/d3fc-webgl/src/series/glArea.js
+++ b/packages/d3fc-webgl/src/series/glArea.js
@@ -1,4 +1,5 @@
 import projectedAttributeBuilder from '../buffers/projectedAttributeBuilder';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 import glScaleBase from '../scale/glScaleBase';
 import programBuilder from '../program/programBuilder';
 import drawModes from '../program/drawModes';
@@ -10,24 +11,18 @@ export default () => {
     let yScale = glScaleBase();
     let decorate = () => {};
 
-    const xValueAttribute = projectedAttributeBuilder().value(
+    const xValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const xPreviousValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
-    const yValueAttribute = projectedAttributeBuilder().value(
+    const xPreviousValueAttribute = elementConstantAttributeBuilder();
+    const yValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const yPreviousValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
-    const y0ValueAttribute = projectedAttributeBuilder().value(
+    const yPreviousValueAttribute = elementConstantAttributeBuilder();
+    const y0ValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const y0PreviousValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const y0PreviousValueAttribute = elementConstantAttributeBuilder();
     const cornerAttribute = projectedAttributeBuilder()
         .size(3)
         .data([

--- a/packages/d3fc-webgl/src/series/glBar.js
+++ b/packages/d3fc-webgl/src/series/glBar.js
@@ -3,6 +3,7 @@ import drawModes from '../program/drawModes';
 import programBuilder from '../program/programBuilder';
 import barShader from '../shaders/bar/shader';
 import { rebind } from '@d3fc/d3fc-rebind';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 //     βL            β            βR
 //     .-------------.------------.
@@ -35,18 +36,14 @@ export default () => {
     let yScale = null;
     let decorate = () => {};
 
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const xValueAttribute = elementConstantAttributeBuilder();
     const yValueAttribute = projectedAttributeBuilder()
         .data([null, null])
         .value((data, element, vertex) => {
             const array = [1, 2, 4].includes(vertex) ? 0 : 1;
             return data[array][element];
         });
-    const widthValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const widthValueAttribute = elementConstantAttributeBuilder();
     const directionAttribute = projectedAttributeBuilder()
         .size(2)
         .data([-1, -1, 1, -1, 1, 1])

--- a/packages/d3fc-webgl/src/series/glBoxPlot.js
+++ b/packages/d3fc-webgl/src/series/glBoxPlot.js
@@ -5,6 +5,7 @@ import boxPlotShader from '../shaders/boxPlot/shader';
 import lineWidthShader from '../shaders/lineWidth';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 //           αL1     α     αR1
 //            .------.------.
@@ -48,9 +49,7 @@ export default () => {
     const decorate = () => {};
     const lineWidth = lineWidthShader();
 
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const xValueAttribute = elementConstantAttributeBuilder();
     const yValueAttribute = projectedAttributeBuilder()
         .data({
             median: null,

--- a/packages/d3fc-webgl/src/series/glCandlestick.js
+++ b/packages/d3fc-webgl/src/series/glCandlestick.js
@@ -5,6 +5,7 @@ import candlestickShader from '../shaders/candlestick/shader';
 import lineWidthShader from '../shaders/lineWidth';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 export default () => {
     const program = programBuilder().verticesPerElement(12);
@@ -13,29 +14,17 @@ export default () => {
     const lineWidth = lineWidthShader();
     let decorate = () => {};
 
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const xValueAttribute = elementConstantAttributeBuilder();
 
-    const highAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const highAttribute = elementConstantAttributeBuilder();
 
-    const openAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const openAttribute = elementConstantAttributeBuilder();
 
-    const closeAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const closeAttribute = elementConstantAttributeBuilder();
 
-    const lowAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const lowAttribute = elementConstantAttributeBuilder();
 
-    const bandwidthAttribute = projectedAttributeBuilder().value(
-        (data, element, vertex) => data[element]
-    );
+    const bandwidthAttribute = elementConstantAttributeBuilder();
 
     /*
      * x-y coordinate to locate the "corners" of the element.

--- a/packages/d3fc-webgl/src/series/glErrorBar.js
+++ b/packages/d3fc-webgl/src/series/glErrorBar.js
@@ -5,6 +5,7 @@ import errorBarShader from '../shaders/errorBar/shader';
 import lineWidthShader from '../shaders/lineWidth';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 export default () => {
     const program = programBuilder().verticesPerElement(18);
@@ -13,21 +14,13 @@ export default () => {
     const decorate = () => {};
     const lineWidth = lineWidthShader();
 
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const xValueAttribute = elementConstantAttributeBuilder();
 
-    const highValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const highValueAttribute = elementConstantAttributeBuilder();
 
-    const lowValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const lowValueAttribute = elementConstantAttributeBuilder();
 
-    const bandwidthAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const bandwidthAttribute = elementConstantAttributeBuilder();
 
     /*
      * x-y coordinate to locate the "corners" of the element (ie errorbar). The `z` coordinate locates the corner relative to the line (this takes line width into account).

--- a/packages/d3fc-webgl/src/series/glLine.js
+++ b/packages/d3fc-webgl/src/series/glLine.js
@@ -6,6 +6,7 @@ import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
 import lineWidthShader from '../shaders/lineWidth';
 import * as vertexShaderSnippets from '../shaders/vertexShaderSnippets';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 export default () => {
     let xScale = glScaleBase();
@@ -13,22 +14,18 @@ export default () => {
     let decorate = () => {};
 
     const lineWidth = lineWidthShader();
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
-    const xNextValueAttribute = projectedAttributeBuilder().value(
+    const xValueAttribute = elementConstantAttributeBuilder();
+    const xNextValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const xPreviousValueAttribute = projectedAttributeBuilder().value(
+    const xPreviousValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.max(element - 1, 0)]
     );
-    const yValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
-    const yNextValueAttribute = projectedAttributeBuilder().value(
+    const yValueAttribute = elementConstantAttributeBuilder();
+    const yNextValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const yPreviousValueAttribute = projectedAttributeBuilder().value(
+    const yPreviousValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.max(element - 1, 0)]
     );
     const cornerAttribute = projectedAttributeBuilder()

--- a/packages/d3fc-webgl/src/series/glOhlc.js
+++ b/packages/d3fc-webgl/src/series/glOhlc.js
@@ -5,6 +5,7 @@ import rectShader from '../shaders/rect/shader';
 import lineWidthShader from '../shaders/lineWidth';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 export default () => {
     const program = programBuilder().verticesPerElement(18);
@@ -13,9 +14,7 @@ export default () => {
     const lineWidth = lineWidthShader();
     let decorate = () => {};
 
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const xValueAttribute = elementConstantAttributeBuilder();
     const yValueAttribute = projectedAttributeBuilder()
         .data({ open: null, high: null, low: null, close: null })
         .value((data, element, vertex) => {

--- a/packages/d3fc-webgl/src/series/glPoint.js
+++ b/packages/d3fc-webgl/src/series/glPoint.js
@@ -1,9 +1,9 @@
-import projectedAttributeBuilder from '../buffers/projectedAttributeBuilder';
 import glScaleBase from '../scale/glScaleBase';
 import programBuilder from '../program/programBuilder';
 import circlePointShader from '../shaders/point/circle/baseShader';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
+import elementConstantAttributeBuilder from '../buffers/elementConstantAttributeBuilder';
 
 export default () => {
     let xScale = glScaleBase();
@@ -11,15 +11,9 @@ export default () => {
     let type = circlePointShader();
     let decorate = () => {};
 
-    const xValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
-    const yValueAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
-    const sizeAttribute = projectedAttributeBuilder().value(
-        (data, element) => data[element]
-    );
+    const xValueAttribute = elementConstantAttributeBuilder();
+    const yValueAttribute = elementConstantAttributeBuilder();
+    const sizeAttribute = elementConstantAttributeBuilder();
 
     const program = programBuilder().mode(drawModes.POINTS);
 


### PR DESCRIPTION
Putting up for early visibility as I'm not sure it's exactly on the money yet, nor am I certain of all of the places it can be used, so feel free to tell me if I'm barking up the wrong tree, or even in the wrong forest entirely.

Tested it with glArea to fill` x/yPreviousValueAttributes`, and can also pass an array to use `vertexAttrib[1234]fv`.

For example, replacing the colorIndicatorAttribute on candlestick with this:
`const colorIndicatorAttribute = elementConstantAttributeBuilder().value(
        [-1]
    );`
will turn every element red. Entering [1] here instead turns them all green.

Linked to https://github.com/d3fc/d3fc/issues/1368

