### PR TITLE
refactor: move glOhlc calculations from JavaScript into web-gl

### DIFF
--- a/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
@@ -44,7 +44,7 @@ export const candlestick = {
     }`
 };
 
-export const rect = {
+export const ohlc = {
     header: `varying float vColorIndicator;`,
     body: `gl_FragColor = vec4(0.4, 0.8, 0, 1);
     if (vColorIndicator < 0.0) {

--- a/packages/d3fc-webgl/src/shaders/ohlc/shader.js
+++ b/packages/d3fc-webgl/src/shaders/ohlc/shader.js
@@ -10,12 +10,12 @@ export default () => {
     const fragmentShader = shaderBuilder(fragmentShaderBase);
 
     vertexShader
-        .appendHeader(vertexShaderSnippets.rect.header)
-        .appendBody(vertexShaderSnippets.rect.body);
+        .appendHeader(vertexShaderSnippets.ohlc.header)
+        .appendBody(vertexShaderSnippets.ohlc.body);
 
     fragmentShader
-        .appendHeader(fragmentShaderSnippets.rect.header)
-        .appendBody(fragmentShaderSnippets.rect.body);
+        .appendHeader(fragmentShaderSnippets.ohlc.header)
+        .appendBody(fragmentShaderSnippets.ohlc.body);
 
     return {
         vertex: () => vertexShader,

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -93,18 +93,37 @@ export const candlestick = {
         gl_Position = vec4(aXValue, yValue, 0, 1);`
 };
 
-export const rect = {
-    header: `attribute float aXValue;
-      attribute float aYValue;
-      attribute float aXDirection;
-      attribute float aYDirection;
+export const ohlc = {
+    header: `
+      attribute float aXValue;
+      attribute float aHigh;
+      attribute float aOpen;
+      attribute float aClose;
+      attribute float aLow;
       attribute float aBandwidth;
-      attribute float aColorIndicator;
+      attribute vec3 aCorner;
+  
       varying float vColorIndicator;
       uniform vec2 uScreen;
       uniform float uLineWidth;`,
-    body: `vColorIndicator = aColorIndicator;
-      gl_Position = vec4(aXValue, aYValue, 0, 1);`
+    body: `
+      vColorIndicator = sign(aClose - aOpen);
+
+      float isPositiveY = (sign(aCorner.y) + 1.0) / 2.0;
+      float isNotPositiveY = 1.0 - isPositiveY;
+      float isExtremeY = abs(aCorner.y) - 1.0;
+      float isNotExtremeY = 1.0 - isExtremeY;
+      float yValue = (isPositiveY * isExtremeY * aLow) + (isPositiveY * isNotExtremeY * aClose) + (isNotPositiveY * isNotExtremeY * aOpen) + (isNotPositiveY * isExtremeY * aHigh);
+
+      float xDirection = isExtremeY * aCorner.z;
+      float yDirection = isNotExtremeY * aCorner.z;
+
+      float bandwidthModifier = isNotExtremeY * aCorner.x * aBandwidth / 2.0;
+
+      float xModifier = (uLineWidth * xDirection / 2.0) + bandwidthModifier;
+      float yModifier = uLineWidth * yDirection / 2.0;
+
+      gl_Position = vec4(aXValue, yValue, 0, 1);`
 };
 
 export const bar = {


### PR DESCRIPTION
Every web-gl attribute, defined in glOhlc.js, now only varies with either element or vertex but not both.

Solves part of: #1371 