### PR TITLE
fix: ensure decorate function is invoked before path rendering

### DIFF
--- a/packages/d3fc-series/src/canvas/area.js
+++ b/packages/d3fc-series/src/canvas/area.js
@@ -22,11 +22,13 @@ export default () => {
         areaData[valueComponent + '1']((_, i) => projectedData[i].y);
 
         context.beginPath();
-        areaData(data);
+
         context.fillStyle = colors.gray;
         context.strokeStyle = 'transparent';
 
         base.decorate()(context, data);
+
+        areaData(data);
 
         context.fill();
         context.stroke();

--- a/packages/d3fc-series/src/canvas/bar.js
+++ b/packages/d3fc-series/src/canvas/bar.js
@@ -35,13 +35,14 @@ export default () => {
             context.beginPath();
             context.translate(datum.origin[0], datum.origin[1]);
 
+            context.fillStyle = colors.darkGray;
+            context.strokeStyle = 'transparent';
+            base.decorate()(context, datum.d, i);
+
             valueAxisDimension(pathGenerator)(-datum.height);
             crossAxisDimension(pathGenerator)(datum.width);
             pathGenerator([datum]);
 
-            context.fillStyle = colors.darkGray;
-            context.strokeStyle = 'transparent';
-            base.decorate()(context, datum.d, i);
             context.fill();
             context.stroke();
 

--- a/packages/d3fc-series/src/canvas/boxPlot.js
+++ b/packages/d3fc-series/src/canvas/boxPlot.js
@@ -23,17 +23,17 @@ export default () => {
             context.translate(values.origin[0], values.origin[1]);
             context.beginPath();
 
+            context.fillStyle = colors.gray;
+            context.strokeStyle = colors.black;
+
+            base.decorate()(context, d, i);
+
             pathGenerator.median(values.median)
                 .upperQuartile(values.upperQuartile)
                 .lowerQuartile(values.lowerQuartile)
                 .high(values.high)
                 .width(values.width)
                 .low(values.low)([d]);
-
-            context.fillStyle = colors.gray;
-            context.strokeStyle = colors.black;
-
-            base.decorate()(context, d, i);
 
             context.fill();
             context.stroke();

--- a/packages/d3fc-series/src/canvas/errorBar.js
+++ b/packages/d3fc-series/src/canvas/errorBar.js
@@ -23,14 +23,14 @@ export default () => {
             context.translate(values.origin[0], values.origin[1]);
             context.beginPath();
 
-            pathGenerator.high(values.high)
-                .width(values.width)
-                .low(values.low)([d]);
-
             context.strokeStyle = colors.black;
             context.fillStyle = colors.gray;
 
             base.decorate()(context, d, i);
+
+            pathGenerator.high(values.high)
+                .width(values.width)
+                .low(values.low)([d]);
 
             context.fill();
             context.stroke();

--- a/packages/d3fc-series/src/canvas/heatmap.js
+++ b/packages/d3fc-series/src/canvas/heatmap.js
@@ -21,10 +21,10 @@ export default () => {
             context.fillStyle = colorInterpolate(colorScale(values.colorValue));
             context.strokeStyle = 'transparent';
 
+            base.decorate()(context, d, i);
+
             base.pathGenerator.height(values.height)
                 .width(values.width)([d]);
-
-            base.decorate()(context, d, i);
 
             context.fill();
             context.stroke();

--- a/packages/d3fc-series/src/canvas/line.js
+++ b/packages/d3fc-series/src/canvas/line.js
@@ -14,11 +14,13 @@ export default () => {
         const context = lineData.context();
 
         context.beginPath();
-        lineData.defined(base.defined())(data);
+
         context.strokeStyle = colors.black;
         context.fillStyle = 'transparent';
 
         base.decorate()(context, data);
+
+        lineData.defined(base.defined())(data);
 
         context.fill();
         context.stroke();

--- a/packages/d3fc-series/src/canvas/point.js
+++ b/packages/d3fc-series/src/canvas/point.js
@@ -20,12 +20,12 @@ export default () => {
             context.translate(values.origin[0], values.origin[1]);
             context.beginPath();
 
-            symbol(d, i);
-
             context.strokeStyle = colors.black;
             context.fillStyle = colors.gray;
 
             base.decorate()(context, d, i);
+
+            symbol(d, i);
 
             context.fill();
             context.stroke();


### PR DESCRIPTION
fixes #1393 - allowing decorate to transform / rotate the canvas context:

![image](https://user-images.githubusercontent.com/1098110/72785877-1ceced80-3c24-11ea-9f6d-cdf4f22c0b26.png)
