### PR TITLE
refactor: convert the web-gl bar series into the standard format and move logic from JS into web-gl

### DIFF
--- a/packages/d3fc-series/examples/bar.js
+++ b/packages/d3fc-series/examples/bar.js
@@ -47,6 +47,5 @@ var webglBar = fc.seriesWebglBar()
     .yScale(yScale)
     .context(gl)
     .crossValue(function(_, i) { return i; })
-    .mainValue(function(d) { return d; })
-    .bandwidth(0.5);
+    .mainValue(function(d) { return d; });
 webglBar(data);

--- a/packages/d3fc-series/src/webgl/bar.js
+++ b/packages/d3fc-series/src/webgl/bar.js
@@ -19,9 +19,9 @@ export default () => {
         const widths = new Float32Array(filteredData.length);
         filteredData.forEach((d, i) => {
             xValues[i] = xScale.scale(base.crossValue()(d, i));
+            widths[i] = xScale.scale(base.bandwidth()(d, i));
             y0Values[i] = yScale.scale(base.baseValue()(d, i));
             yValues[i] = yScale.scale(base.mainValue()(d, i));
-            widths[i] = yScale.scale(base.bandwidth()(d, i));
         });
 
         draw.xValues(xValues)

--- a/packages/d3fc-webgl/src/series/glErrorBar.js
+++ b/packages/d3fc-webgl/src/series/glErrorBar.js
@@ -76,8 +76,8 @@ export default () => {
         lineWidth(program);
 
         program.vertexShader().appendBody(`
-                gl_Position.x += xModifier / uScreen.x;
-                gl_Position.y += yModifier / uScreen.y;
+                gl_Position.x += xModifier / uScreen.x * 2.0;
+                gl_Position.y += yModifier / uScreen.y * 2.0;
             `);
 
         decorate(program);

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -128,13 +128,21 @@ export const ohlc = {
 
 export const bar = {
     header: `attribute float aXValue;
+        attribute float aY0Value;
         attribute float aYValue;
         attribute float aWidthValue;
-        attribute float aDirection;`,
-    body: `gl_Position = vec4(aXValue, aYValue, 0, 1);
-        vec4 origin = vec4(0.0, 0.0, 0.0, 0.0);
-        vec4 width = vec4(aWidthValue, 0.0, 0.0, 0.0);
-        gl_Position.x += (width.x - origin.x) / 2.0 * aDirection;`
+        attribute vec2 aCorner;
+        
+        uniform vec2 uScreen;
+        uniform float uLineWidth;`,
+    body: `
+        float isBaseline = (1.0 - aCorner.y) / 2.0;
+        float yValue = (isBaseline * aY0Value) + ((1.0 - isBaseline) * aYValue);
+
+        float xModifier = aCorner.x * (aWidthValue) / 2.0;
+
+        gl_Position = vec4(aXValue, yValue, 0, 1);
+        `
 };
 
 export const preScaleLine = {

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -200,7 +200,7 @@ export const errorBar = {
         
         gl_Position = vec4(aXValue, yValue, 0, 1);
         
-        float xModifier = ((uLineWidth * lineWidthXDirection) + (aBandwidth * aCorner.x));
+        float xModifier = ((uLineWidth * lineWidthXDirection) + (aBandwidth * aCorner.x / 2.0));
         float yModifier = (uLineWidth * lineWidthYDirection);
     `
 };


### PR DESCRIPTION
Solves part of #1371 

In addition to standardising the web-gl bar by moving logic into GLSL, this fixes #1365.

The second commit is a minor refactor of the error bar in order to make the scaling match the convention of the bar. However, the ohlc and candlestick do not match this convention (there may be further work involved in this beyond a minor refactor so has not been addressed here).