### PR TITLE
fix: move dirty check and baseAttributeBuilder call

### DIFF
--- a/packages/d3fc-webgl/src/buffers/baseAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/baseAttributeBuilder.js
@@ -7,11 +7,14 @@ export default () => {
     let normalized = false;
     let stride = 0;
     let offset = 0;
+    let validSize = 0;
 
     const base = (gl, program, name) => {
-        if (buffer == null) {
+        if (buffer == null || !gl.isBuffer(buffer)) {
             buffer = gl.createBuffer();
+            validSize = 0;
         }
+
         gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
         const location = gl.getAttribLocation(program, name);
         gl.vertexAttribPointer(
@@ -25,11 +28,20 @@ export default () => {
         gl.enableVertexAttribArray(location);
     };
 
+    base.validSize = (...args) => {
+        if (!args.length) {
+            return validSize;
+        }
+        validSize = args[0];
+        return base;
+    };
+
     base.buffer = (...args) => {
         if (!args.length) {
             return buffer;
         }
         buffer = args[0];
+        validSize = 0;
         return base;
     };
 
@@ -38,6 +50,7 @@ export default () => {
             return size;
         }
         size = args[0];
+        validSize = 0;
         return base;
     };
 
@@ -46,6 +59,7 @@ export default () => {
             return type;
         }
         type = args[0];
+        validSize = 0;
         return base;
     };
 
@@ -54,6 +68,7 @@ export default () => {
             return normalized;
         }
         normalized = args[0];
+        validSize = 0;
         return base;
     };
 
@@ -62,6 +77,7 @@ export default () => {
             return stride;
         }
         stride = args[0];
+        validSize = 0;
         return base;
     };
 
@@ -70,6 +86,7 @@ export default () => {
             return offset;
         }
         offset = args[0];
+        validSize = 0;
         return base;
     };
 

--- a/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
@@ -6,7 +6,6 @@ export default () => {
 
     let value = (data, element, vertex, component, index) => data[element];
     let data = null;
-    let validSize = 0;
 
     const project = (elementCount, verticesPerElement) => {
         const components = base.size();
@@ -31,7 +30,7 @@ export default () => {
     };
 
     const build = (gl, program, name, verticesPerElement, count) => {
-        if (validSize >= count) {
+        if (base.validSize() >= count) {
             return;
         }
 
@@ -56,7 +55,7 @@ export default () => {
         } else {
             throw new Error(`Expected function or array, received: ${value}`);
         }
-        validSize = count;
+        base.validSize(count);
     };
 
     build.value = (...args) => {
@@ -64,7 +63,7 @@ export default () => {
             return value;
         }
         value = args[0];
-        validSize = 0;
+        base.validSize(0);
         return build;
     };
 
@@ -73,7 +72,7 @@ export default () => {
             return data;
         }
         data = args[0];
-        validSize = 0;
+        base.validSize(0);
         return build;
     };
 

--- a/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
@@ -30,11 +30,11 @@ export default () => {
     };
 
     const build = (gl, program, name, verticesPerElement, count) => {
+        base(gl, program, name);
+
         if (base.validSize() >= count) {
             return;
         }
-
-        base(gl, program, name);
 
         if (typeof value === 'function') {
             const projectedData = project(count, verticesPerElement);

--- a/packages/d3fc-webgl/src/buffers/projectedAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/projectedAttributeBuilder.js
@@ -31,13 +31,13 @@ export default () => {
     };
 
     const build = (gl, program, name, verticesPerElement, count) => {
+        base(gl, program, name);
+
         if (base.validSize() >= count) {
             return;
         }
 
         const projectedData = project(count, verticesPerElement);
-
-        base(gl, program, name);
 
         gl.bindBuffer(gl.ARRAY_BUFFER, base.buffer());
         gl.bufferData(gl.ARRAY_BUFFER, projectedData, gl.DYNAMIC_DRAW);

--- a/packages/d3fc-webgl/src/buffers/projectedAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/projectedAttributeBuilder.js
@@ -6,7 +6,6 @@ export default () => {
 
     let value = (data, element, vertex, component, index) => data[index];
     let data = null;
-    let validSize = 0;
 
     const project = (elementCount, verticesPerElement) => {
         const components = base.size();
@@ -32,7 +31,7 @@ export default () => {
     };
 
     const build = (gl, program, name, verticesPerElement, count) => {
-        if (validSize >= count) {
+        if (base.validSize() >= count) {
             return;
         }
 
@@ -43,7 +42,7 @@ export default () => {
         gl.bindBuffer(gl.ARRAY_BUFFER, base.buffer());
         gl.bufferData(gl.ARRAY_BUFFER, projectedData, gl.DYNAMIC_DRAW);
 
-        validSize = count;
+        base.validSize(count);
     };
 
     build.value = (...args) => {
@@ -51,7 +50,7 @@ export default () => {
             return value;
         }
         value = args[0];
-        validSize = 0;
+        base.validSize(0);
         return build;
     };
 
@@ -60,7 +59,7 @@ export default () => {
             return data;
         }
         data = args[0];
-        validSize = 0;
+        base.validSize(0);
         return build;
     };
 


### PR DESCRIPTION
Moves the dirty check variable `validSize` to `baseAttributeBuilder` allowing base properties to be considered, this fixes https://github.com/d3fc/d3fc/issues/1367

Moves the call to `baseAttributeBuilder` to before the dirty check in `projectedAttributeBuilder` and `elementConstantAttributeBuilder`, this fixes https://github.com/d3fc/d3fc/issues/1398