### PR TITLE
feat: add equals function to d3fc-series webgl implementations

### DIFF
--- a/packages/d3fc-series/src/isIdentityScale.js
+++ b/packages/d3fc-series/src/isIdentityScale.js
@@ -1,0 +1,3 @@
+import d3Scale from 'd3-scale';
+
+export default (scale) => scale.copy.toString() === d3Scale.scaleIdentity().copy.toString();

--- a/packages/d3fc-series/src/webgl/area.js
+++ b/packages/d3fc-series/src/webgl/area.js
@@ -1,4 +1,5 @@
 import xyBase from '../xyBase';
+import isIdentityScale from '../isIdentityScale';
 import { glArea, scaleMapper } from '@d3fc/d3fc-webgl';
 import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
 
@@ -7,31 +8,47 @@ export default () => {
 
     const draw = glArea();
 
+    let equals = (previousData, data) => false;
+    let previousData = [];
+
     const area = (data) => {
         const xScale = scaleMapper(base.xScale());
         const yScale = scaleMapper(base.yScale());
 
-        const xValues = new Float32Array(data.length);
-        const yValues = new Float32Array(data.length);
-        const y0Values = new Float32Array(data.length);
-        const defined = new Float32Array(data.length);
+        if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
+            previousData = data;
 
-        data.forEach((d, i) => {
-            xValues[i] = xScale.scale(base.crossValue()(d, i));
-            yValues[i] = yScale.scale(base.mainValue()(d, i));
-            y0Values[i] = yScale.scale(base.baseValue()(d, i));
-            defined[i] = base.defined()(d, i);
-        });
+            const xValues = new Float32Array(data.length);
+            const yValues = new Float32Array(data.length);
+            const y0Values = new Float32Array(data.length);
+            const defined = new Float32Array(data.length);
 
-        draw.xValues(xValues)
-            .yValues(yValues)
-            .y0Values(y0Values)
-            .defined(defined)
-            .xScale(xScale.glScale)
+            data.forEach((d, i) => {
+                xValues[i] = xScale.scale(base.crossValue()(d, i));
+                yValues[i] = yScale.scale(base.mainValue()(d, i));
+                y0Values[i] = yScale.scale(base.baseValue()(d, i));
+                defined[i] = base.defined()(d, i);
+            });
+
+            draw.xValues(xValues)
+                .yValues(yValues)
+                .y0Values(y0Values)
+                .defined(defined);
+        }
+
+        draw.xScale(xScale.glScale)
             .yScale(yScale.glScale)
             .decorate((program) => base.decorate()(program, data, 0));
 
         draw(data.length);
+    };
+
+    area.equals = (...args) => {
+        if (!args.length) {
+            return equals;
+        }
+        equals = args[0];
+        return area;
     };
 
     rebindAll(area, base, exclude('bandwidth', 'align'));

--- a/packages/d3fc-series/src/webgl/bar.js
+++ b/packages/d3fc-series/src/webgl/bar.js
@@ -1,4 +1,5 @@
 import xyBase from '../xyBase';
+import isIdentityScale from '../isIdentityScale';
 import { glBar, scaleMapper } from '@d3fc/d3fc-webgl';
 import { exclude, rebind, rebindAll } from '@d3fc/d3fc-rebind';
 
@@ -7,33 +8,48 @@ export default () => {
 
     const draw = glBar();
 
+    let equals = (previousData, data) => false;
+    let previousData = [];
+
     const bar = (data) => {
         const filteredData = data.filter(base.defined());
 
         const xScale = scaleMapper(base.xScale());
         const yScale = scaleMapper(base.yScale());
 
-        const xValues = new Float32Array(filteredData.length);
-        const y0Values = new Float32Array(filteredData.length);
-        const yValues = new Float32Array(filteredData.length);
-        const widths = new Float32Array(filteredData.length);
-        filteredData.forEach((d, i) => {
-            xValues[i] = xScale.scale(base.crossValue()(d, i));
-            widths[i] = xScale.scale(base.bandwidth()(d, i));
-            y0Values[i] = yScale.scale(base.baseValue()(d, i));
-            yValues[i] = yScale.scale(base.mainValue()(d, i));
-        });
+        if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
+            previousData = data;
 
-        draw.xValues(xValues)
-            .y0Values(y0Values)
-            .yValues(yValues)
-            .widths(widths)
-            .xScale(xScale.glScale)
-            .yScale(yScale.glScale)
-            .decorate((program) => {
-                base.decorate()(program, filteredData, 0);
+            const xValues = new Float32Array(filteredData.length);
+            const y0Values = new Float32Array(filteredData.length);
+            const yValues = new Float32Array(filteredData.length);
+            const widths = new Float32Array(filteredData.length);
+            filteredData.forEach((d, i) => {
+                xValues[i] = xScale.scale(base.crossValue()(d, i));
+                widths[i] = xScale.scale(base.bandwidth()(d, i));
+                y0Values[i] = yScale.scale(base.baseValue()(d, i));
+                yValues[i] = yScale.scale(base.mainValue()(d, i));
             });
+
+            draw.xValues(xValues)
+                .y0Values(y0Values)
+                .yValues(yValues)
+                .widths(widths);
+        }
+
+        draw.xScale(xScale.glScale)
+            .yScale(yScale.glScale)
+            .decorate((program) => base.decorate()(program, filteredData, 0));
+
         draw(filteredData.length);
+    };
+
+    bar.equals = (...args) => {
+        if (!args.length) {
+            return equals;
+        }
+        equals = args[0];
+        return bar;
     };
 
     rebindAll(bar, base, exclude('align'));

--- a/packages/d3fc-series/src/webgl/boxPlot.js
+++ b/packages/d3fc-series/src/webgl/boxPlot.js
@@ -1,4 +1,5 @@
 import boxPlotBase from '../boxPlotBase';
+import isIdentityScale from '../isIdentityScale';
 import { glBoxPlot, scaleMapper } from '@d3fc/d3fc-webgl';
 import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
 import functor from '../functor';
@@ -9,41 +10,49 @@ export default () => {
 
     const draw = glBoxPlot();
 
+    let equals = (previousData, data) => false;
+    let previousData = [];
+
     const boxPlot = (data) => {
         const filteredData = data.filter(base.defined());
 
         const xScale = scaleMapper(base.xScale());
         const yScale = scaleMapper(base.yScale());
+
+        if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
+            previousData = data;
         
-        const xValues = new Float32Array(filteredData.length);
-        const medianValues = new Float32Array(filteredData.length);
-        const upperQuartileValues = new Float32Array(filteredData.length);
-        const lowerQuartileValues = new Float32Array(filteredData.length);
-        const highValues = new Float32Array(filteredData.length);
-        const lowValues = new Float32Array(filteredData.length);
-        const bandwidth = new Float32Array(filteredData.length);
-        const capWidth = new Float32Array(filteredData.length);
+            const xValues = new Float32Array(filteredData.length);
+            const medianValues = new Float32Array(filteredData.length);
+            const upperQuartileValues = new Float32Array(filteredData.length);
+            const lowerQuartileValues = new Float32Array(filteredData.length);
+            const highValues = new Float32Array(filteredData.length);
+            const lowValues = new Float32Array(filteredData.length);
+            const bandwidth = new Float32Array(filteredData.length);
+            const capWidth = new Float32Array(filteredData.length);
 
-        filteredData.forEach((d, i) => {
-            xValues[i] = xScale.scale(base.crossValue()(d, i));
-            medianValues[i] = yScale.scale(base.medianValue()(d, i));
-            upperQuartileValues[i] = yScale.scale(base.upperQuartileValue()(d, i));
-            lowerQuartileValues[i] = xScale.scale(base.lowerQuartileValue()(d, i));
-            highValues[i] = yScale.scale(base.highValue()(d, i));
-            lowValues[i] = yScale.scale(base.lowValue()(d, i));
-            bandwidth[i] = base.bandwidth()(d, i);
-            capWidth[i] = bandwidth[i] * cap(d, i);
-        });
+            filteredData.forEach((d, i) => {
+                xValues[i] = xScale.scale(base.crossValue()(d, i));
+                medianValues[i] = yScale.scale(base.medianValue()(d, i));
+                upperQuartileValues[i] = yScale.scale(base.upperQuartileValue()(d, i));
+                lowerQuartileValues[i] = xScale.scale(base.lowerQuartileValue()(d, i));
+                highValues[i] = yScale.scale(base.highValue()(d, i));
+                lowValues[i] = yScale.scale(base.lowValue()(d, i));
+                bandwidth[i] = base.bandwidth()(d, i);
+                capWidth[i] = bandwidth[i] * cap(d, i);
+            });
 
-        draw.xValues(xValues)
-            .medianValues(medianValues)
-            .upperQuartileValues(upperQuartileValues)
-            .lowerQuartileValues(lowerQuartileValues)
-            .highValues(highValues)
-            .lowValues(lowValues)
-            .bandwidth(bandwidth)
-            .capWidth(capWidth)
-            .xScale(xScale.glScale)
+            draw.xValues(xValues)
+                .medianValues(medianValues)
+                .upperQuartileValues(upperQuartileValues)
+                .lowerQuartileValues(lowerQuartileValues)
+                .highValues(highValues)
+                .lowValues(lowValues)
+                .bandwidth(bandwidth)
+                .capWidth(capWidth);
+        }
+
+        draw.xScale(xScale.glScale)
             .yScale(yScale.glScale);
 
         draw(filteredData.length);
@@ -54,6 +63,14 @@ export default () => {
             return cap;
         }
         cap = functor(args[0]);
+        return boxPlot;
+    };
+
+    boxPlot.equals = (...args) => {
+        if (!args.length) {
+            return equals;
+        }
+        equals = args[0];
         return boxPlot;
     };
     

--- a/packages/d3fc-series/src/webgl/errorBar.js
+++ b/packages/d3fc-series/src/webgl/errorBar.js
@@ -1,4 +1,5 @@
 import errorBarBase from '../errorBarBase';
+import isIdentityScale from '../isIdentityScale';
 import { glErrorBar, scaleMapper  } from '@d3fc/d3fc-webgl';
 import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
 
@@ -7,32 +8,48 @@ export default () => {
 
     const draw = glErrorBar();
 
+    let equals = (previousData, data) => false;
+    let previousData = [];
+
     const errorBar = (data) => {
         const filteredData = data.filter(base.defined());
 
         const xScale = scaleMapper(base.xScale());
         const yScale = scaleMapper(base.yScale());
 
-        const xValues = new Float32Array(filteredData.length);
-        const high = new Float32Array(filteredData.length);
-        const low = new Float32Array(filteredData.length);
-        const bandwidth = new Float32Array(filteredData.length);
+        if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
+            previousData = data;
 
-        filteredData.forEach((d, i) => {
-            xValues[i] = xScale.scale(base.crossValue()(d, i));
-            high[i] = yScale.scale(base.highValue()(d, i));
-            low[i] = yScale.scale(base.lowValue()(d, i));
-            bandwidth[i] = base.bandwidth()(d, i);
-        });
+            const xValues = new Float32Array(filteredData.length);
+            const high = new Float32Array(filteredData.length);
+            const low = new Float32Array(filteredData.length);
+            const bandwidth = new Float32Array(filteredData.length);
 
-        draw.xValues(xValues)
-            .highValues(high)
-            .lowValues(low)
-            .bandwidth(bandwidth)
-            .xScale(xScale.glScale)
+            filteredData.forEach((d, i) => {
+                xValues[i] = xScale.scale(base.crossValue()(d, i));
+                high[i] = yScale.scale(base.highValue()(d, i));
+                low[i] = yScale.scale(base.lowValue()(d, i));
+                bandwidth[i] = base.bandwidth()(d, i);
+            });
+
+            draw.xValues(xValues)
+                .highValues(high)
+                .lowValues(low)
+                .bandwidth(bandwidth);
+        }
+
+        draw.xScale(xScale.glScale)
             .yScale(yScale.glScale);
 
         draw(filteredData.length);
+    };
+
+    errorBar.equals = (...args) => {
+        if (!args.length) {
+            return equals;
+        }
+        equals = args[0];
+        return errorBar;
     };
 
     rebindAll(errorBar, base,  exclude('align'));

--- a/packages/d3fc-series/src/webgl/ohlcBase.js
+++ b/packages/d3fc-series/src/webgl/ohlcBase.js
@@ -1,9 +1,13 @@
 import ohlcBase from '../ohlcBase';
+import isIdentityScale from '../isIdentityScale';
 import { scaleMapper } from '@d3fc/d3fc-webgl';
 import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
 
 export default (pathGenerator) => {
     const base = ohlcBase();
+
+    let equals = (previousData, data) => false;
+    let previousData = [];
 
     const candlestick = (data) => {
         const filteredData = data.filter(base.defined());
@@ -11,33 +15,46 @@ export default (pathGenerator) => {
         const xScale = scaleMapper(base.xScale());
         const yScale = scaleMapper(base.yScale());
 
-        const xValues = new Float32Array(filteredData.length);
-        const open = new Float32Array(filteredData.length);
-        const high = new Float32Array(filteredData.length);
-        const low = new Float32Array(filteredData.length);
-        const close = new Float32Array(filteredData.length);
-        const bandwidths = new Float32Array(filteredData.length);
+        if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
+            previousData = data;
 
-        filteredData.forEach((d, i) => {
-            xValues[i] = xScale.scale(base.crossValue()(d, i));
-            open[i] = yScale.scale(base.openValue()(d, i));
-            high[i] = yScale.scale(base.highValue()(d, i));
-            low[i] = yScale.scale(base.lowValue()(d, i));
-            close[i] = yScale.scale(base.closeValue()(d, i));
-            bandwidths[i] = base.bandwidth()(d, i);
-        });
+            const xValues = new Float32Array(filteredData.length);
+            const open = new Float32Array(filteredData.length);
+            const high = new Float32Array(filteredData.length);
+            const low = new Float32Array(filteredData.length);
+            const close = new Float32Array(filteredData.length);
+            const bandwidths = new Float32Array(filteredData.length);
 
-        pathGenerator.xValues(xValues)
-            .openValues(open)
-            .highValues(high)
-            .lowValues(low)
-            .closeValues(close)
-            .bandwidth(bandwidths)
-            .xScale(xScale.glScale)
+            filteredData.forEach((d, i) => {
+                xValues[i] = xScale.scale(base.crossValue()(d, i));
+                open[i] = yScale.scale(base.openValue()(d, i));
+                high[i] = yScale.scale(base.highValue()(d, i));
+                low[i] = yScale.scale(base.lowValue()(d, i));
+                close[i] = yScale.scale(base.closeValue()(d, i));
+                bandwidths[i] = base.bandwidth()(d, i);
+            });
+
+            pathGenerator.xValues(xValues)
+                .openValues(open)
+                .highValues(high)
+                .lowValues(low)
+                .closeValues(close)
+                .bandwidth(bandwidths);
+        }
+
+        pathGenerator.xScale(xScale.glScale)
             .yScale(yScale.glScale)
             .decorate((program) => base.decorate()(program, filteredData, 0));
 
         pathGenerator(filteredData.length);
+    };
+
+    candlestick.equals = (...args) => {
+        if (!args.length) {
+            return equals;
+        }
+        equals = args[0];
+        return candlestick;
     };
 
     rebindAll(candlestick, base, exclude('align'));


### PR DESCRIPTION
Adds an `equals` function to each of the d3fc-series WebGL implementations, the function takes the previous data and current data as arguments.

We use the `equals` function to skip the creation of `xValues`, `yValues`, etc. data arrays if the data hasn't changed. By default we return `false`, assuming that the data has always changed.

This implements point 1 of https://github.com/d3fc/d3fc/issues/1366