### PR TITLE
Use drawArraysInstancedANGLE()

### DIFF
--- a/packages/d3fc-webgl/src/buffers/baseAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/baseAttributeBuilder.js
@@ -8,8 +8,9 @@ export default () => {
     let stride = 0;
     let offset = 0;
     let validSize = 0;
+    let divisor = 0;
 
-    const base = (gl, program, name) => {
+    const base = (gl, program, name, verticesPerElement) => {
         if (buffer == null || !gl.isBuffer(buffer)) {
             buffer = gl.createBuffer();
             validSize = 0;
@@ -19,13 +20,17 @@ export default () => {
         const location = gl.getAttribLocation(program, name);
         gl.vertexAttribPointer(
             location,
-            base.size(),
-            base.type(),
-            base.normalized(),
-            base.stride(),
-            base.offset()
+            size,
+            type,
+            normalized,
+            stride,
+            offset
         );
         gl.enableVertexAttribArray(location);
+        if (verticesPerElement !== 1) {
+            const ext = gl.getExtension('ANGLE_instanced_arrays');
+            ext.vertexAttribDivisorANGLE(location, divisor);
+        }
     };
 
     base.validSize = (...args) => {
@@ -87,6 +92,14 @@ export default () => {
         }
         offset = args[0];
         validSize = 0;
+        return base;
+    };
+
+    base.divisor = (...args) => {
+        if (!args.length) {
+            return divisor;
+        }
+        divisor = args[0];
         return base;
     };
 

--- a/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
@@ -2,42 +2,38 @@ import baseAttributeBuilder from './baseAttributeBuilder';
 import { rebindAll, exclude } from '@d3fc/d3fc-rebind';
 
 export default () => {
-    const base = baseAttributeBuilder();
+    const base = baseAttributeBuilder().divisor(1);
 
     let value = (data, element, vertex, component, index) => data[element];
     let data = null;
 
-    const project = (elementCount, verticesPerElement) => {
+    const project = elementCount => {
         const components = base.size();
         const offset = base.offset();
         const projectedData = new Float32Array(
-            offset + elementCount * verticesPerElement * components
+            offset + elementCount * components
         );
         let element = 0;
         for (
             let index = offset;
             index < projectedData.length;
-            index += verticesPerElement * components
+            index += components
         ) {
-            projectedData.fill(
-                value(data, element),
-                index,
-                index + verticesPerElement * components
-            );
+            projectedData.fill(value(data, element), index, index + components);
             element++;
         }
         return projectedData;
     };
 
     const build = (gl, program, name, verticesPerElement, count) => {
-        base(gl, program, name);
+        base(gl, program, name, verticesPerElement);
 
         if (base.validSize() >= count) {
             return;
         }
 
         if (typeof value === 'function') {
-            const projectedData = project(count, verticesPerElement);
+            const projectedData = project(count);
             gl.bindBuffer(gl.ARRAY_BUFFER, base.buffer());
             gl.bufferData(gl.ARRAY_BUFFER, projectedData, gl.DYNAMIC_DRAW);
         } else if (Array.isArray(value)) {

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -26,7 +26,12 @@ export default () => {
         );
         buffers(context, program, verticesPerElement, count);
 
-        context.drawArrays(mode, 0, count * verticesPerElement);
+        if (verticesPerElement !== 1) {
+            var ext = context.getExtension('ANGLE_instanced_arrays');
+            ext.drawArraysInstancedANGLE(mode, 0, verticesPerElement, count);
+        } else {
+            context.drawArrays(mode, 0, count * verticesPerElement);
+        }
     };
 
     build.context = (...args) => {


### PR DESCRIPTION
Should no longer be blocked - line and point now working, though perhaps not in the most graceful way for the latter.

Uses ANGLE instancing extension to draw vertex and element constants with fewer draw calls.
See here: https://github.com/d3fc/d3fc/issues/1369.