### PR TITLE
refactor: change elementConstantAttributeBuilder loop comparison to less than

### DIFF
--- a/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
+++ b/packages/d3fc-webgl/src/buffers/elementConstantAttributeBuilder.js
@@ -16,7 +16,7 @@ export default () => {
         let element = 0;
         for (
             let index = offset;
-            index <= projectedData.length;
+            index < projectedData.length;
             index += verticesPerElement * components
         ) {
             projectedData.fill(


### PR DESCRIPTION
Changes the comparison in the loop for `elementConstantAttributeBuilder` from `<=` to `<`