### PR TITLE
refactor: changes line draw type to triangles

### DIFF
--- a/packages/d3fc-webgl/src/series/glLine.js
+++ b/packages/d3fc-webgl/src/series/glLine.js
@@ -14,54 +14,65 @@ export default () => {
     let decorate = () => {};
 
     const lineWidth = lineWidthShader();
-    const xValueAttribute = elementConstantAttributeBuilder();
-    const xNextValueAttribute = elementConstantAttributeBuilder().value(
+    const xValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const xPreviousValueAttribute = elementConstantAttributeBuilder().value(
+    const xNextValueAttribute = elementConstantAttributeBuilder().value(
+        (data, element) => data[Math.min(element + 2, data.length - 1)]
+    );
+    const xPreviousValueAttribute = elementConstantAttributeBuilder();
+    const xPreviousPreviousValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.max(element - 1, 0)]
     );
-    const yValueAttribute = elementConstantAttributeBuilder();
-    const yNextValueAttribute = elementConstantAttributeBuilder().value(
+    const yValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.min(element + 1, data.length - 1)]
     );
-    const yPreviousValueAttribute = elementConstantAttributeBuilder().value(
+    const yNextValueAttribute = elementConstantAttributeBuilder().value(
+        (data, element) => data[Math.min(element + 2, data.length - 1)]
+    );
+    const yPreviousValueAttribute = elementConstantAttributeBuilder();
+    const yPreviousPreviousValueAttribute = elementConstantAttributeBuilder().value(
         (data, element) => data[Math.max(element - 1, 0)]
     );
     const cornerAttribute = vertexConstantAttributeBuilder()
-        .size(2)
+        .size(3)
         .data([
-            [-1, -1],
-            [1, -1],
-            [-1, 1],
-            [1, 1]
+            [-1, 0, 0],
+            [1, 1, 0],
+            [1, -1, 1],
+            [1, 1, 0],
+            [1, -1, 1],
+            [-1, 0, 1],
+            [-1, 0, 0],
+            [1, -1, 1],
+            [-1, 0, 1],
+            [1, -1, 1],
+            [-1, 0, 1],
+            [1, 1, 1]
         ]);
     const definedAttribute = elementConstantAttributeBuilder().value(
-        (data, element, vertex, component) => {
+        (data, element) => {
             const value = data[element];
-            if (vertex <= 1) {
-                const previousValue = element === 0 ? value : data[element - 1];
-                return value ? previousValue : value;
-            } else {
-                const nextValue =
-                    element === data.length - 1 ? value : data[element + 1];
-                return value ? nextValue : value;
-            }
+            const nextValue =
+                element === data.length - 1 ? 0 : data[element + 1];
+            return value ? nextValue : value;
         }
     );
 
     const program = programBuilder()
-        .mode(drawModes.TRIANGLE_STRIP)
-        .verticesPerElement(4);
+        .mode(drawModes.TRIANGLES)
+        .verticesPerElement(12);
 
     program
         .buffers()
         .attribute('aXValue', xValueAttribute)
         .attribute('aNextXValue', xNextValueAttribute)
         .attribute('aPrevXValue', xPreviousValueAttribute)
+        .attribute('aPrevPrevXValue', xPreviousPreviousValueAttribute)
         .attribute('aYValue', yValueAttribute)
         .attribute('aNextYValue', yNextValueAttribute)
         .attribute('aPrevYValue', yPreviousValueAttribute)
+        .attribute('aPrevPrevYValue', yPreviousPreviousValueAttribute)
         .attribute('aCorner', cornerAttribute)
         .attribute('aDefined', definedAttribute);
 
@@ -79,6 +90,8 @@ export default () => {
         yScale.scaleComponent(program, 'next');
         xScale.scaleComponent(program, 'prev');
         yScale.scaleComponent(program, 'prev');
+        xScale.scaleComponent(program, 'prevPrev');
+        yScale.scaleComponent(program, 'prevPrev');
 
         program
             .vertexShader()
@@ -88,13 +101,14 @@ export default () => {
 
         decorate(program);
 
-        program(numElements);
+        program(numElements - 1);
     };
 
     draw.xValues = data => {
         xValueAttribute.data(data);
         xNextValueAttribute.data(data);
         xPreviousValueAttribute.data(data);
+        xPreviousPreviousValueAttribute.data(data);
         return draw;
     };
 
@@ -102,6 +116,7 @@ export default () => {
         yValueAttribute.data(data);
         yNextValueAttribute.data(data);
         yPreviousValueAttribute.data(data);
+        yPreviousPreviousValueAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -146,39 +146,61 @@ export const bar = {
 };
 
 export const preScaleLine = {
-    header: `uniform float uLineWidth; // defines the width of the line
-        uniform vec2 uScreen; // the screen space canvas size (for normalizing vectors)
-        attribute vec2 aCorner; // defines which vertex in the line join we are considering
-        attribute float aXValue; attribute float aYValue; // the current vertex positions
-        attribute float aNextXValue; attribute float aNextYValue; // the next vertex positions
-        attribute float aPrevXValue; attribute float aPrevYValue; // the previous vertex positions
+    header: `uniform float uLineWidth;
+        uniform vec2 uScreen;
+        attribute vec3 aCorner;
+        attribute float aNextXValue; attribute float aNextYValue;
+        attribute float aXValue; attribute float aYValue;
+        attribute float aPrevXValue; attribute float aPrevYValue;
+        attribute float aPrevPrevXValue; attribute float aPrevPrevYValue;
         attribute float aDefined;
         varying float vDefined;`,
     body: `vDefined = aDefined;
-        vec4 curr = vec4(aXValue, aYValue, 0, 1);
-        gl_Position = curr;
         vec4 next = vec4(aNextXValue, aNextYValue, 0, 0);
-        vec4 prev = vec4(aPrevXValue, aPrevYValue, 0, 0);`
+        gl_Position = vec4(aXValue, aYValue, 0, 1);
+        vec4 prev = vec4(aPrevXValue, aPrevYValue, 0, 0);
+        vec4 prevPrev = vec4(aPrevPrevXValue, aPrevPrevYValue, 0, 0);`
 };
 
 export const postScaleLine = {
-    body: `if (all(equal(gl_Position.xy, prev.xy))) {
-            prev.xy = gl_Position.xy + normalize(gl_Position.xy - next.xy);
-        }
-        if (all(equal(gl_Position.xy, next.xy))) {
-            next.xy = gl_Position.xy + normalize(gl_Position.xy - prev.xy);
-        }
-        vec2 A = normalize(normalize(gl_Position.xy - prev.xy) * uScreen);
-        vec2 B = normalize(normalize(next.xy - gl_Position.xy) * uScreen);
-        vec2 tangent = normalize(A + B);
-        vec2 miter = vec2(-tangent.y, tangent.x);
-        vec2 normalA = vec2(-A.y, A.x);
-        float miterLength = 1.0 / dot(miter, normalA);
-        vec2 point = normalize(A - B);
-        if (miterLength > 10.0 && sign(aCorner.x * dot(miter, point)) > 0.0) {
-            gl_Position.xy = gl_Position.xy - (aCorner.x * aCorner.y * uLineWidth * normalA) / uScreen.xy;
+    body: `if (aCorner.z < 0.5) {
+            if (all(equal(prev.xy, prevPrev.xy))) {
+                prevPrev.xy = prev.xy + normalize(prev.xy - gl_Position.xy);
+            }
+            if (all(equal(prev.xy, gl_Position.xy))) {
+                gl_Position.xy = prev.xy + normalize(prev.xy - prevPrev.xy);
+            }
+            vec2 A = normalize(normalize(prev.xy - prevPrev.xy) * uScreen);
+            vec2 B = normalize(normalize(gl_Position.xy - prev.xy) * uScreen);
+            vec2 tangent = normalize(A + B);
+            vec2 miter = vec2(-tangent.y, tangent.x);
+            vec2 normalA = vec2(-A.y, A.x);
+            float miterLength = 1.0 / dot(miter, normalA);
+            vec2 point = normalize(A - B);
+            if (miterLength > 10.0 && sign(aCorner.x * dot(miter, point)) > 0.0) {
+                gl_Position.xy = prev.xy - (aCorner.x * aCorner.y * uLineWidth * normalA) / uScreen.xy;
+            } else {
+                gl_Position.xy = prev.xy + (aCorner.x * miter * uLineWidth * miterLength) / uScreen.xy;
+            }
         } else {
-            gl_Position.xy = gl_Position.xy + (aCorner.x * miter * uLineWidth * miterLength) / uScreen.xy;
+            if (all(equal(gl_Position.xy, prev.xy))) {
+                prev.xy = gl_Position.xy + normalize(gl_Position.xy - next.xy);
+            }
+            if (all(equal(gl_Position.xy, next.xy))) {
+                next.xy = gl_Position.xy + normalize(gl_Position.xy - prev.xy);
+            }
+            vec2 A = normalize(normalize(gl_Position.xy - prev.xy) * uScreen);
+            vec2 B = normalize(normalize(next.xy - gl_Position.xy) * uScreen);
+            vec2 tangent = normalize(A + B);
+            vec2 miter = vec2(-tangent.y, tangent.x);
+            vec2 normalA = vec2(-A.y, A.x);
+            float miterLength = 1.0 / dot(miter, normalA);
+            vec2 point = normalize(A - B);
+            if (miterLength > 10.0 && sign(aCorner.x * dot(miter, point)) > 0.0) {
+                gl_Position.xy = gl_Position.xy - (aCorner.x * aCorner.y * uLineWidth * normalA) / uScreen.xy;
+            } else {
+                gl_Position.xy = gl_Position.xy + (aCorner.x * miter * uLineWidth * miterLength) / uScreen.xy;
+            }
         }`
 };
 


### PR DESCRIPTION
This changes the draw type for `glLine` to `TRIANGLES` and updates the shader to reflect this, fixing #1406 

This is an initial implementation and the shader could most likely be refined