### PR TITLE
test: add toHaveGlPositionTo4Dp() to expectVertexShader()

### DIFF
--- a/packages/d3fc-webgl/test/util/vertextShaderUtil.js
+++ b/packages/d3fc-webgl/test/util/vertextShaderUtil.js
@@ -21,11 +21,26 @@ export const getShaders = element => {
 };
 
 export const expectVertexShader = (shader, attributes, uniforms) => {
+    const shaderOutput = executeVertexShader(shader, attributes, uniforms);
+
     return {
-        toHaveGlPosition: glPosition =>
-            expect(executeVertexShader(shader, attributes, uniforms)).toEqual({
+        toHaveGlPositionExact: glPosition =>
+            expect(shaderOutput).toEqual({
                 gl_Position: glPosition
-            })
+            }),
+        toHaveGlPosition: glPosition => {
+            const TEN_THOUSAND = 10000;
+
+            shaderOutput.gl_Position = shaderOutput.gl_Position.map(
+                x =>
+                    Math.round((x + Number.EPSILON) * TEN_THOUSAND) /
+                    TEN_THOUSAND
+            );
+
+            return expect(shaderOutput).toEqual({
+                gl_Position: glPosition
+            });
+        }
     };
 };
 


### PR DESCRIPTION
This addresses a [comment](https://github.com/d3fc/d3fc/pull/1420/files#r373404235) on #1420 about excessively long `gl_Position` values.