### PR TITLE
refactor: add defined attribute to all webgl series

### DIFF
--- a/packages/d3fc-series/src/webgl/bar.js
+++ b/packages/d3fc-series/src/webgl/bar.js
@@ -10,7 +10,6 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
-    let filteredData = [];
 
     const bar = (data) => {
         const xScale = scaleMapper(base.xScale());
@@ -18,30 +17,33 @@ export default () => {
 
         if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
             previousData = data;
-            filteredData = data.filter(base.defined());
 
-            const xValues = new Float32Array(filteredData.length);
-            const y0Values = new Float32Array(filteredData.length);
-            const yValues = new Float32Array(filteredData.length);
-            const widths = new Float32Array(filteredData.length);
-            filteredData.forEach((d, i) => {
+            const xValues = new Float32Array(data.length);
+            const y0Values = new Float32Array(data.length);
+            const yValues = new Float32Array(data.length);
+            const widths = new Float32Array(data.length);
+            const defined = new Float32Array(data.length);
+
+            data.forEach((d, i) => {
                 xValues[i] = xScale.scale(base.crossValue()(d, i));
                 widths[i] = xScale.scale(base.bandwidth()(d, i));
                 y0Values[i] = yScale.scale(base.baseValue()(d, i));
                 yValues[i] = yScale.scale(base.mainValue()(d, i));
+                defined[i] = base.defined()(d, i);
             });
 
             draw.xValues(xValues)
                 .y0Values(y0Values)
                 .yValues(yValues)
-                .widths(widths);
+                .widths(widths)
+                .defined(defined);
         }
 
         draw.xScale(xScale.glScale)
             .yScale(yScale.glScale)
-            .decorate((program) => base.decorate()(program, filteredData, 0));
+            .decorate((program) => base.decorate()(program, data, 0));
 
-        draw(filteredData.length);
+        draw(data.length);
     };
 
     bar.equals = (...args) => {

--- a/packages/d3fc-series/src/webgl/boxPlot.js
+++ b/packages/d3fc-series/src/webgl/boxPlot.js
@@ -12,7 +12,6 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
-    let filteredData = [];
 
     const boxPlot = (data) => {
         const xScale = scaleMapper(base.xScale());
@@ -20,18 +19,18 @@ export default () => {
 
         if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
             previousData = data;
-            filteredData = data.filter(base.defined());
         
-            const xValues = new Float32Array(filteredData.length);
-            const medianValues = new Float32Array(filteredData.length);
-            const upperQuartileValues = new Float32Array(filteredData.length);
-            const lowerQuartileValues = new Float32Array(filteredData.length);
-            const highValues = new Float32Array(filteredData.length);
-            const lowValues = new Float32Array(filteredData.length);
-            const bandwidth = new Float32Array(filteredData.length);
-            const capWidth = new Float32Array(filteredData.length);
+            const xValues = new Float32Array(data.length);
+            const medianValues = new Float32Array(data.length);
+            const upperQuartileValues = new Float32Array(data.length);
+            const lowerQuartileValues = new Float32Array(data.length);
+            const highValues = new Float32Array(data.length);
+            const lowValues = new Float32Array(data.length);
+            const bandwidth = new Float32Array(data.length);
+            const capWidth = new Float32Array(data.length);
+            const defined = new Float32Array(data.length);
 
-            filteredData.forEach((d, i) => {
+            data.forEach((d, i) => {
                 xValues[i] = xScale.scale(base.crossValue()(d, i));
                 medianValues[i] = yScale.scale(base.medianValue()(d, i));
                 upperQuartileValues[i] = yScale.scale(base.upperQuartileValue()(d, i));
@@ -40,6 +39,7 @@ export default () => {
                 lowValues[i] = yScale.scale(base.lowValue()(d, i));
                 bandwidth[i] = base.bandwidth()(d, i);
                 capWidth[i] = bandwidth[i] * cap(d, i);
+                defined[i] = base.defined()(d, i);
             });
 
             draw.xValues(xValues)
@@ -49,13 +49,15 @@ export default () => {
                 .highValues(highValues)
                 .lowValues(lowValues)
                 .bandwidth(bandwidth)
-                .capWidth(capWidth);
+                .capWidth(capWidth)
+                .defined(defined);
         }
 
         draw.xScale(xScale.glScale)
-            .yScale(yScale.glScale);
+            .yScale(yScale.glScale)
+            .decorate((program) => base.decorate()(program, data, 0));
 
-        draw(filteredData.length);
+        draw(data.length);
     };
 
     boxPlot.cap = (...args) => {

--- a/packages/d3fc-series/src/webgl/errorBar.js
+++ b/packages/d3fc-series/src/webgl/errorBar.js
@@ -10,7 +10,6 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
-    let filteredData = [];
 
     const errorBar = (data) => {
         const xScale = scaleMapper(base.xScale());
@@ -18,30 +17,33 @@ export default () => {
 
         if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
             previousData = data;
-            filteredData = data.filter(base.defined());
 
-            const xValues = new Float32Array(filteredData.length);
-            const high = new Float32Array(filteredData.length);
-            const low = new Float32Array(filteredData.length);
-            const bandwidth = new Float32Array(filteredData.length);
+            const xValues = new Float32Array(data.length);
+            const high = new Float32Array(data.length);
+            const low = new Float32Array(data.length);
+            const bandwidth = new Float32Array(data.length);
+            const defined = new Float32Array(data.length);
 
-            filteredData.forEach((d, i) => {
+            data.forEach((d, i) => {
                 xValues[i] = xScale.scale(base.crossValue()(d, i));
                 high[i] = yScale.scale(base.highValue()(d, i));
                 low[i] = yScale.scale(base.lowValue()(d, i));
                 bandwidth[i] = base.bandwidth()(d, i);
+                defined[i] = base.defined()(d, i);
             });
 
             draw.xValues(xValues)
                 .highValues(high)
                 .lowValues(low)
-                .bandwidth(bandwidth);
+                .bandwidth(bandwidth)
+                .defined(defined);
         }
 
         draw.xScale(xScale.glScale)
-            .yScale(yScale.glScale);
+            .yScale(yScale.glScale)
+            .decorate((program) => base.decorate()(program, data, 0));
 
-        draw(filteredData.length);
+        draw(data.length);
     };
 
     errorBar.equals = (...args) => {

--- a/packages/d3fc-series/src/webgl/ohlcBase.js
+++ b/packages/d3fc-series/src/webgl/ohlcBase.js
@@ -8,7 +8,6 @@ export default (pathGenerator) => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
-    let filteredData = [];
 
     const candlestick = (data) => {
         const xScale = scaleMapper(base.xScale());
@@ -16,22 +15,23 @@ export default (pathGenerator) => {
 
         if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
             previousData = data;
-            filteredData = data.filter(base.defined());
 
-            const xValues = new Float32Array(filteredData.length);
-            const open = new Float32Array(filteredData.length);
-            const high = new Float32Array(filteredData.length);
-            const low = new Float32Array(filteredData.length);
-            const close = new Float32Array(filteredData.length);
-            const bandwidths = new Float32Array(filteredData.length);
+            const xValues = new Float32Array(data.length);
+            const open = new Float32Array(data.length);
+            const high = new Float32Array(data.length);
+            const low = new Float32Array(data.length);
+            const close = new Float32Array(data.length);
+            const bandwidths = new Float32Array(data.length);
+            const defined = new Float32Array(data.length);
 
-            filteredData.forEach((d, i) => {
+            data.forEach((d, i) => {
                 xValues[i] = xScale.scale(base.crossValue()(d, i));
                 open[i] = yScale.scale(base.openValue()(d, i));
                 high[i] = yScale.scale(base.highValue()(d, i));
                 low[i] = yScale.scale(base.lowValue()(d, i));
                 close[i] = yScale.scale(base.closeValue()(d, i));
                 bandwidths[i] = base.bandwidth()(d, i);
+                defined[i] = base.defined()(d, i);
             });
 
             pathGenerator.xValues(xValues)
@@ -39,14 +39,15 @@ export default (pathGenerator) => {
                 .highValues(high)
                 .lowValues(low)
                 .closeValues(close)
-                .bandwidth(bandwidths);
+                .bandwidth(bandwidths)
+                .defined(defined);
         }
 
         pathGenerator.xScale(xScale.glScale)
             .yScale(yScale.glScale)
-            .decorate((program) => base.decorate()(program, filteredData, 0));
+            .decorate((program) => base.decorate()(program, data, 0));
 
-        pathGenerator(filteredData.length);
+        pathGenerator(data.length);
     };
 
     candlestick.equals = (...args) => {

--- a/packages/d3fc-series/src/webgl/point.js
+++ b/packages/d3fc-series/src/webgl/point.js
@@ -13,7 +13,6 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
-    let filteredData = [];
 
     const point = (data) => {
         const xScale = scaleMapper(base.xScale());
@@ -21,31 +20,34 @@ export default () => {
 
         if (isIdentityScale(xScale.scale) && isIdentityScale(yScale.scale) && !equals(previousData, data)) {
             previousData = data;
-            filteredData = data.filter(base.defined());
 
             const accessor = getAccessors();
 
-            const xValues = new Float32Array(filteredData.length);
-            const yValues = new Float32Array(filteredData.length);
-            const sizes = new Float32Array(filteredData.length);
-            filteredData.forEach((d, i) => {
+            const xValues = new Float32Array(data.length);
+            const yValues = new Float32Array(data.length);
+            const sizes = new Float32Array(data.length);
+            const defined = new Float32Array(data.length);
+
+            data.forEach((d, i) => {
                 const sizeFn = typeof size === 'function' ? size : () => size;
                 xValues[i] = xScale.scale(accessor.x(d, i));
                 yValues[i] = yScale.scale(accessor.y(d, i));
                 sizes[i] = sizeFn(d);
+                defined[i] = base.defined()(d, i);
             });
 
             draw.xValues(xValues)
                 .yValues(yValues)
-                .sizes(sizes);
+                .sizes(sizes)
+                .defined(defined);
         }
 
         draw.xScale(xScale.glScale)
             .yScale(yScale.glScale)
             .type(symbolMapper(type))
-            .decorate((program) => base.decorate()(program, filteredData, 0));
+            .decorate((program) => base.decorate()(program, data, 0));
 
-        draw(filteredData.length);
+        draw(data.length);
     };
 
     function getAccessors() {

--- a/packages/d3fc-webgl/src/series/glBar.js
+++ b/packages/d3fc-webgl/src/series/glBar.js
@@ -55,6 +55,8 @@ export default () => {
             [1, -1]
         ]);
 
+    const definedAttribute = elementConstantAttributeBuilder();
+
     const elementIndices = elementIndicesBuilder().data([0, 1, 2, 0, 1, 3]);
 
     const draw = numElements => {
@@ -71,7 +73,8 @@ export default () => {
             .attribute('aCrossValue', xValueAttribute)
             .attribute('aMainValue', yValueAttribute)
             .attribute('aBaseValue', y0ValueAttribute)
-            .attribute('aBandwidth', widthValueAttribute);
+            .attribute('aBandwidth', widthValueAttribute)
+            .attribute('aDefined', definedAttribute);
 
         xScale.coordinate(0);
         xScale(program);
@@ -104,6 +107,11 @@ export default () => {
 
     draw.widths = data => {
         widthValueAttribute.data(data);
+        return draw;
+    };
+
+    draw.defined = data => {
+        definedAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/series/glBoxPlot.js
+++ b/packages/d3fc-webgl/src/series/glBoxPlot.js
@@ -123,6 +123,8 @@ export default () => {
             [-1, 2, 1, 1]
         ]);
 
+    const definedAttribute = elementConstantAttributeBuilder();
+
     const elementIndices = elementIndicesBuilder().data([
         // Top cap line
         0,
@@ -207,7 +209,8 @@ export default () => {
             .attribute('aLowValue', lowAttribute)
             .attribute('aBandwidth', bandwidthAttribute)
             .attribute('aCap', capWidthAttribute)
-            .attribute('aCorner', cornerAttribute);
+            .attribute('aCorner', cornerAttribute)
+            .attribute('aDefined', definedAttribute);
 
         xScale.coordinate(0);
         xScale(program);
@@ -263,6 +266,11 @@ export default () => {
 
     draw.capWidth = data => {
         capWidthAttribute.data(data);
+        return draw;
+    };
+
+    draw.defined = data => {
+        definedAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/series/glCandlestick.js
+++ b/packages/d3fc-webgl/src/series/glCandlestick.js
@@ -48,6 +48,8 @@ export default () => {
             [1, 1, 0]
         ]);
 
+    const definedAttribute = elementConstantAttributeBuilder();
+
     const elementIndices = elementIndicesBuilder().data([
         // Vertical line
         0,
@@ -81,7 +83,8 @@ export default () => {
             .attribute('aCloseValue', closeAttribute)
             .attribute('aLowValue', lowAttribute)
             .attribute('aBandwidth', bandwidthAttribute)
-            .attribute('aCorner', cornerAttribute);
+            .attribute('aCorner', cornerAttribute)
+            .attribute('aDefined', definedAttribute);
 
         xScale.coordinate(0);
         xScale(program);
@@ -127,6 +130,11 @@ export default () => {
 
     draw.bandwidth = data => {
         bandwidthAttribute.data(data);
+        return draw;
+    };
+
+    draw.defined = data => {
+        definedAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/series/glErrorBar.js
+++ b/packages/d3fc-webgl/src/series/glErrorBar.js
@@ -49,6 +49,8 @@ export default () => {
             [1, 1, -1]
         ]);
 
+    const definedAttribute = elementConstantAttributeBuilder();
+
     const elementIndices = elementIndicesBuilder().data([
         // Main stem
         0,
@@ -87,7 +89,8 @@ export default () => {
             .attribute('aHighValue', highValueAttribute)
             .attribute('aLowValue', lowValueAttribute)
             .attribute('aBandwidth', bandwidthAttribute)
-            .attribute('aCorner', cornerAttribute);
+            .attribute('aCorner', cornerAttribute)
+            .attribute('aDefined', definedAttribute);
 
         xScale.coordinate(0);
         xScale(program);
@@ -123,6 +126,11 @@ export default () => {
 
     draw.bandwidth = data => {
         bandwidthAttribute.data(data);
+        return draw;
+    };
+
+    draw.defined = data => {
+        definedAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/series/glOhlc.js
+++ b/packages/d3fc-webgl/src/series/glOhlc.js
@@ -53,6 +53,8 @@ export default () => {
             [1, 1, -1]
         ]);
 
+    const definedAttribute = elementConstantAttributeBuilder();
+
     const elementIndices = elementIndicesBuilder().data([
         // Main stem
         0,
@@ -93,7 +95,8 @@ export default () => {
             .attribute('aCloseValue', closeAttribute)
             .attribute('aLowValue', lowAttribute)
             .attribute('aBandwidth', bandwidthAttribute)
-            .attribute('aCorner', cornerAttribute);
+            .attribute('aCorner', cornerAttribute)
+            .attribute('aDefined', definedAttribute);
 
         xScale.coordinate(0);
         xScale(program);
@@ -139,6 +142,11 @@ export default () => {
 
     draw.bandwidth = data => {
         bandwidthAttribute.data(data);
+        return draw;
+    };
+
+    draw.defined = data => {
+        definedAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/series/glPoint.js
+++ b/packages/d3fc-webgl/src/series/glPoint.js
@@ -14,6 +14,7 @@ export default () => {
     const xValueAttribute = elementConstantAttributeBuilder();
     const yValueAttribute = elementConstantAttributeBuilder();
     const sizeAttribute = elementConstantAttributeBuilder();
+    const definedAttribute = elementConstantAttributeBuilder();
 
     const program = programBuilder().mode(drawModes.POINTS);
 
@@ -21,7 +22,8 @@ export default () => {
         .buffers()
         .attribute('aCrossValue', xValueAttribute)
         .attribute('aMainValue', yValueAttribute)
-        .attribute('aSize', sizeAttribute);
+        .attribute('aSize', sizeAttribute)
+        .attribute('aDefined', definedAttribute);
 
     const draw = numElements => {
         program.vertexShader(type.vertex()).fragmentShader(type.fragment());
@@ -48,6 +50,11 @@ export default () => {
 
     draw.sizes = data => {
         sizeAttribute.data(data);
+        return draw;
+    };
+
+    draw.defined = data => {
+        definedAttribute.data(data);
         return draw;
     };
 

--- a/packages/d3fc-webgl/src/shaders/bar/shader.js
+++ b/packages/d3fc-webgl/src/shaders/bar/shader.js
@@ -3,6 +3,7 @@ import shaderBuilder, {
     fragmentShaderBase
 } from '../shaderBuilder';
 import * as vertexShaderSnippets from '../vertexShaderSnippets';
+import * as fragmentShaderSnippets from '../fragmentShaderSnippets';
 
 export default () => {
     const vertexShader = shaderBuilder(vertexShaderBase);
@@ -11,6 +12,10 @@ export default () => {
     vertexShader
         .appendHeader(vertexShaderSnippets.bar.header)
         .appendBody(vertexShaderSnippets.bar.body);
+
+    fragmentShader
+        .appendHeader(fragmentShaderSnippets.bar.header)
+        .appendBody(fragmentShaderSnippets.bar.body);
 
     return {
         vertex: () => vertexShader,

--- a/packages/d3fc-webgl/src/shaders/boxPlot/shader.js
+++ b/packages/d3fc-webgl/src/shaders/boxPlot/shader.js
@@ -3,6 +3,7 @@ import shaderBuilder, {
     fragmentShaderBase
 } from '../shaderBuilder';
 import * as vertexShaderSnippets from '../vertexShaderSnippets';
+import * as fragmentShaderSnippets from '../fragmentShaderSnippets';
 
 export default () => {
     const vertexShader = shaderBuilder(vertexShaderBase);
@@ -11,6 +12,10 @@ export default () => {
     vertexShader
         .appendHeader(vertexShaderSnippets.boxPlot.header)
         .appendBody(vertexShaderSnippets.boxPlot.body);
+
+    fragmentShader
+        .appendHeader(fragmentShaderSnippets.boxPlot.header)
+        .appendBody(fragmentShaderSnippets.boxPlot.body);
 
     return {
         vertex: () => vertexShader,

--- a/packages/d3fc-webgl/src/shaders/errorBar/shader.js
+++ b/packages/d3fc-webgl/src/shaders/errorBar/shader.js
@@ -3,6 +3,7 @@ import shaderBuilder, {
     fragmentShaderBase
 } from '../shaderBuilder';
 import * as vertexShaderSnippets from '../vertexShaderSnippets';
+import * as fragmentShaderSnippets from '../fragmentShaderSnippets';
 
 export default () => {
     const vertexShader = shaderBuilder(vertexShaderBase);
@@ -11,6 +12,10 @@ export default () => {
     vertexShader
         .appendHeader(vertexShaderSnippets.errorBar.header)
         .appendBody(vertexShaderSnippets.errorBar.body);
+
+    fragmentShader
+        .appendHeader(fragmentShaderSnippets.errorBar.header)
+        .appendBody(fragmentShaderSnippets.errorBar.body);
 
     return {
         vertex: () => vertexShader,

--- a/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
@@ -1,55 +1,82 @@
 export const circle = {
-    header: `varying float vSize;`,
-    body: `float distance = length(2.0 * gl_PointCoord - 1.0);
-    if (distance > 1.0) {
-        discard;
-        return;
-    }`
+    header: `
+        varying float vSize;
+        varying float vDefined;`,
+    body: `
+        float distance = length(2.0 * gl_PointCoord - 1.0);
+        if (distance > 1.0 || vDefined < 0.5) {
+            discard;
+            return;
+        }`
 };
 
 export const square = {
-    header: `varying float vSize;`,
-    body: `vec2 pointCoordTransform = 2.0 * gl_PointCoord - 1.0;
+    header: `
+        varying float vSize;
+        varying float vDefined;`,
+    body: `
+        if (vDefined < 0.5) {
+            discard;
+        }
+        vec2 pointCoordTransform = 2.0 * gl_PointCoord - 1.0;
         float distance = max(abs(pointCoordTransform.x), abs(pointCoordTransform.y));`
 };
 
 export const triangle = {
-    header: `varying float vSize;`,
-    body: `vec2 pointCoordTransform = 2.0 * gl_PointCoord - 1.0;
-    float topEdgesDistance = abs(pointCoordTransform.x) - ((pointCoordTransform.y - 0.6) / sqrt(3.0));
-    float bottomEdgeDistance = pointCoordTransform.y + 0.5;
-    float distance = max(topEdgesDistance, bottomEdgeDistance);
-    if (distance > 1.0) {
-        discard;
-    }`
+    header: `
+        varying float vSize;
+        varying float vDefined;`,
+    body: `
+        vec2 pointCoordTransform = 2.0 * gl_PointCoord - 1.0;
+        float topEdgesDistance = abs(pointCoordTransform.x) - ((pointCoordTransform.y - 0.6) / sqrt(3.0));
+        float bottomEdgeDistance = pointCoordTransform.y + 0.5;
+        float distance = max(topEdgesDistance, bottomEdgeDistance);
+        if (distance > 1.0 || vDefined < 0.5) {
+            discard;
+        }`
 };
 
 export const cross = {
-    header: `varying float vSize;
-            varying float vStrokeWidthRatio;`,
-    body: `vec2 pointCoordTransform = 2.0 * gl_PointCoord - 1.0;
-    float innerCornerDistance = min(abs(pointCoordTransform.x), abs(pointCoordTransform.y)) + 0.66 - vStrokeWidthRatio;
-    float outerEdgeDistance = max(abs(pointCoordTransform.x), abs(pointCoordTransform.y));
-    float distance = max(innerCornerDistance, outerEdgeDistance);
-    if (distance > 1.0) {
-        discard;
-    }`
+    header: `
+        varying float vSize;
+        varying float vStrokeWidthRatio;
+        varying float vDefined;`,
+    body: `
+        vec2 pointCoordTransform = 2.0 * gl_PointCoord - 1.0;
+        float innerCornerDistance = min(abs(pointCoordTransform.x), abs(pointCoordTransform.y)) + 0.66 - vStrokeWidthRatio;
+        float outerEdgeDistance = max(abs(pointCoordTransform.x), abs(pointCoordTransform.y));
+        float distance = max(innerCornerDistance, outerEdgeDistance);
+        if (distance > 1.0 || vDefined < 0.5) {
+            discard;
+        }`
 };
 
 export const candlestick = {
-    header: `varying float vColorIndicator;`,
-    body: `gl_FragColor = vec4(0.4, 0.8, 0, 1);
-    if (vColorIndicator < 0.0) {
-        gl_FragColor = vec4(0.8, 0.4, 0, 1);
-    }`
+    header: `
+        varying float vColorIndicator;
+        varying float vDefined;`,
+    body: `
+        if (vDefined < 0.5) {
+            discard;
+        }
+        gl_FragColor = vec4(0.4, 0.8, 0, 1);
+        if (vColorIndicator < 0.0) {
+            gl_FragColor = vec4(0.8, 0.4, 0, 1);
+        }`
 };
 
 export const ohlc = {
-    header: `varying float vColorIndicator;`,
-    body: `gl_FragColor = vec4(0.4, 0.8, 0, 1);
-    if (vColorIndicator < 0.0) {
-        gl_FragColor = vec4(0.8, 0.4, 0, 1);
-    }`
+    header: `
+        varying float vColorIndicator;
+        varying float vDefined;`,
+    body: `
+        if (vDefined < 0.5) {
+            discard;
+        }
+        gl_FragColor = vec4(0.4, 0.8, 0, 1);
+        if (vColorIndicator < 0.0) {
+            gl_FragColor = vec4(0.8, 0.4, 0, 1);
+        }`
 };
 
 export const area = {
@@ -58,6 +85,30 @@ export const area = {
             discard;
         }
         gl_FragColor = vec4(0.86, 0.86, 0.86, 1);`
+};
+
+export const boxPlot = {
+    header: `varying float vDefined;`,
+    body: `
+        if (vDefined < 0.5) {
+            discard;
+        }`
+};
+
+export const errorBar = {
+    header: `varying float vDefined;`,
+    body: `
+        if (vDefined < 0.5) {
+            discard;
+        }`
+};
+
+export const bar = {
+    header: `varying float vDefined;`,
+    body: `
+        if (vDefined < 0.5) {
+            discard;
+        }`
 };
 
 export const pointAlias = {

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -15,46 +15,74 @@ export const multiColor = {
 };
 
 export const circle = {
-    header: `attribute float aCrossValue;
-             attribute float aMainValue;
-             attribute float aSize;
-             uniform float uStrokeWidth;
-             varying float vSize;`,
-    body: `vSize = 2.0 * sqrt(aSize / 3.14159);
-           gl_PointSize = vSize + uStrokeWidth + 1.0;
-           gl_Position = vec4(aCrossValue, aMainValue, 0, 1);`
+    header: `
+        attribute float aCrossValue;
+        attribute float aMainValue;
+        attribute float aSize;
+        attribute float aDefined;
+
+        uniform float uStrokeWidth;
+
+        varying float vSize;
+        varying float vDefined;`,
+    body: `
+        vDefined = aDefined;
+        vSize = 2.0 * sqrt(aSize / 3.14159);
+        gl_PointSize = vSize + uStrokeWidth + 1.0;
+        gl_Position = vec4(aCrossValue, aMainValue, 0, 1);`
 };
 
 export const square = {
-    header: `attribute float aCrossValue;
+    header: `
+        attribute float aCrossValue;
         attribute float aMainValue;
         attribute float aSize;
+        attribute float aDefined;
+
         uniform float uStrokeWidth;
-        varying float vSize;`,
-    body: `vSize = sqrt(aSize);
+
+        varying float vSize;
+        varying float vDefined;`,
+    body: `
+        vDefined = aDefined;
+        vSize = sqrt(aSize);
         gl_PointSize = vSize + uStrokeWidth + 1.0;
         gl_Position = vec4(aCrossValue, aMainValue, 0, 1);`
 };
 
 export const triangle = {
-    header: `attribute float aCrossValue;
+    header: `
+        attribute float aCrossValue;
         attribute float aMainValue;
         attribute float aSize;
+        attribute float aDefined;
+
         uniform float uStrokeWidth;
-        varying float vSize;`,
-    body: `vSize = sqrt((16.0 * aSize) / (3.0 * sqrt(3.0)));
+
+        varying float vSize;
+        varying float vDefined;`,
+    body: `
+        vDefined = aDefined;
+        vSize = sqrt((16.0 * aSize) / (3.0 * sqrt(3.0)));
         gl_PointSize = vSize + uStrokeWidth + 1.0;
         gl_Position = vec4(aCrossValue, aMainValue, 0, 1);`
 };
 
 export const cross = {
-    header: `attribute float aCrossValue;
+    header: `
+        attribute float aCrossValue;
         attribute float aMainValue;
         attribute float aSize;
+        attribute float aDefined;
+
         uniform float uStrokeWidth;
+
         varying float vSize;
-        varying float vStrokeWidthRatio;`,
-    body: `vSize = 3.0 * sqrt(aSize / 5.0);
+        varying float vStrokeWidthRatio;
+        varying float vDefined;`,
+    body: `
+        vDefined = aDefined;
+        vSize = 3.0 * sqrt(aSize / 5.0);
         vStrokeWidthRatio = uStrokeWidth / (vSize + uStrokeWidth + 1.0);
         gl_PointSize = vSize + uStrokeWidth + 1.0;
         gl_Position = vec4(aCrossValue, aMainValue, 0, 1);`
@@ -69,11 +97,15 @@ export const candlestick = {
         attribute float aCloseValue;
         attribute float aLowValue;
         attribute vec3 aCorner;
+        attribute float aDefined;
     
-        varying float vColorIndicator;
         uniform vec2 uScreen;
-        uniform float uStrokeWidth;`,
+        uniform float uStrokeWidth;
+        
+        varying float vColorIndicator;
+        varying float vDefined`,
     body: `
+        vDefined = aDefined;
         vColorIndicator = sign(aCloseValue - aOpenValue);
 
         float isPositiveY = (sign(aCorner.y) + 1.0) / 2.0;
@@ -99,39 +131,43 @@ export const candlestick = {
 
 export const ohlc = {
     header: `
-      attribute float aCrossValue;
-      attribute float aBandwidth;
-      attribute float aHighValue;
-      attribute float aOpenValue;
-      attribute float aCloseValue;
-      attribute float aLowValue;
-      attribute vec3 aCorner;
+        attribute float aCrossValue;
+        attribute float aBandwidth;
+        attribute float aHighValue;
+        attribute float aOpenValue;
+        attribute float aCloseValue;
+        attribute float aLowValue;
+        attribute vec3 aCorner;
+        attribute float aDefined;
 
-      varying float vColorIndicator;
-      uniform vec2 uScreen;
-      uniform float uStrokeWidth;`,
+        uniform vec2 uScreen;
+        uniform float uStrokeWidth;
+
+        varying float vColorIndicator;
+        varying float vDefined;`,
     body: `
-      vColorIndicator = sign(aCloseValue - aOpenValue);
+        vDefined = aDefined;
+        vColorIndicator = sign(aCloseValue - aOpenValue);
 
-      float isPositiveY = (sign(aCorner.y) + 1.0) / 2.0;
-      float isNotPositiveY = 1.0 - isPositiveY;
-      float isExtremeY = abs(aCorner.y) - 1.0;
-      float isNotExtremeY = 1.0 - isExtremeY;
-      float yValue = 
-        (isPositiveY * isExtremeY * aLowValue) + 
-        (isPositiveY * isNotExtremeY * aCloseValue) +
-        (isNotPositiveY * isNotExtremeY * aOpenValue) +
-        (isNotPositiveY * isExtremeY * aHighValue);
+        float isPositiveY = (sign(aCorner.y) + 1.0) / 2.0;
+        float isNotPositiveY = 1.0 - isPositiveY;
+        float isExtremeY = abs(aCorner.y) - 1.0;
+        float isNotExtremeY = 1.0 - isExtremeY;
+        float yValue = 
+            (isPositiveY * isExtremeY * aLowValue) + 
+            (isPositiveY * isNotExtremeY * aCloseValue) +
+            (isNotPositiveY * isNotExtremeY * aOpenValue) +
+            (isNotPositiveY * isExtremeY * aHighValue);
 
-      float lineWidthXDirection = isExtremeY * aCorner.z;
-      float lineWidthYDirection = isNotExtremeY * aCorner.z;
+        float lineWidthXDirection = isExtremeY * aCorner.z;
+        float lineWidthYDirection = isNotExtremeY * aCorner.z;
 
-      float bandwidthModifier = isNotExtremeY * aCorner.x * aBandwidth / 2.0;
+        float bandwidthModifier = isNotExtremeY * aCorner.x * aBandwidth / 2.0;
 
-      float xModifier = (uStrokeWidth * lineWidthXDirection / 2.0) + bandwidthModifier;
-      float yModifier = uStrokeWidth * lineWidthYDirection / 2.0;
+        float xModifier = (uStrokeWidth * lineWidthXDirection / 2.0) + bandwidthModifier;
+        float yModifier = uStrokeWidth * lineWidthYDirection / 2.0;
 
-      gl_Position = vec4(aCrossValue, yValue, 0, 1);`
+        gl_Position = vec4(aCrossValue, yValue, 0, 1);`
 };
 
 export const bar = {
@@ -141,17 +177,20 @@ export const bar = {
         attribute float aMainValue;
         attribute float aBaseValue;
         attribute vec2 aCorner;
+        attribute float aDefined;
         
         uniform vec2 uScreen;
-        uniform float uStrokeWidth;`,
+        uniform float uStrokeWidth;
+        
+        varying float vDefined;`,
     body: `
+        vDefined = aDefined;
         float isBaseline = (1.0 - aCorner.y) / 2.0;
         float yValue = (isBaseline * aBaseValue) + ((1.0 - isBaseline) * aMainValue);
 
         float xModifier = aCorner.x * (aBandwidth) / 2.0;
 
-        gl_Position = vec4(aCrossValue, yValue, 0, 1);
-        `
+        gl_Position = vec4(aCrossValue, yValue, 0, 1);`
 };
 
 export const preScaleLine = {
@@ -171,7 +210,8 @@ export const preScaleLine = {
         uniform vec2 uScreen;
 
         varying float vDefined;`,
-    body: `vDefined = aDefined;
+    body: `
+        vDefined = aDefined;
         vec4 next = vec4(aCrossNextValue, aMainNextValue, 0, 0);
         gl_Position = vec4(aCrossValue, aMainValue, 0, 1);
         vec4 prev = vec4(aCrossPrevValue, aMainPrevValue, 0, 0);
@@ -179,7 +219,8 @@ export const preScaleLine = {
 };
 
 export const postScaleLine = {
-    body: `vec4 prevVertexPosition = gl_Position;
+    body: `
+        vec4 prevVertexPosition = gl_Position;
         vec4 currVertexPosition = gl_Position;
         
         if (all(equal(prev.xy, prevPrev.xy))) {
@@ -230,10 +271,14 @@ export const errorBar = {
         attribute float aBandwidth;
         attribute float aHighValue;
         attribute float aLowValue;
+        attribute float aDefined;
 
         uniform vec2 uScreen;
-        uniform float uStrokeWidth;`,
+        uniform float uStrokeWidth;
+        
+        varying float vDefined;`,
     body: `
+        vDefined = aDefined;
         float isLow = (aCorner.y + 1.0) / 2.0;
         float yValue = isLow * aLowValue + (1.0 - isLow) * aHighValue;
 
@@ -244,8 +289,7 @@ export const errorBar = {
         gl_Position = vec4(aCrossValue, yValue, 0, 1);
         
         float xModifier = (uStrokeWidth * lineWidthXDirection) + (aBandwidth * aCorner.x / 2.0);
-        float yModifier = (uStrokeWidth * lineWidthYDirection);
-    `
+        float yModifier = (uStrokeWidth * lineWidthYDirection);`
 };
 
 export const area = {
@@ -268,7 +312,8 @@ export const area = {
         float and(float a, float b) {
             return a * b;
         }`,
-    body: `vDefined = aDefined;
+    body: `
+        vDefined = aDefined;
         gl_Position = vec4(0, 0, 0, 1);
 
         float hasIntercepted = when_lt((aMainValue - aBaseValue) * (aMainPrevValue - aBasePrevValue), 0.0);
@@ -302,10 +347,14 @@ export const boxPlot = {
         attribute float aMedianValue;
         attribute float aLowerQuartileValue;
         attribute float aLowValue;
+        attribute float aDefined;
 
         uniform vec2 uScreen;
-        uniform float uStrokeWidth;`,
-    body: `   
+        uniform float uStrokeWidth;
+        
+        varying float vDefined;`,
+    body: `
+        vDefined = aDefined;
         float isExtremeY = sign(abs(aCorner.y) - 2.0) + 1.0;
         float isNotExtremeY = 1.0 - isExtremeY;
 
@@ -332,6 +381,5 @@ export const boxPlot = {
         float xDisplacement = aCorner.x * (isExtremeY * aCap + isNotExtremeY * aBandwidth) / 2.0;
         
         float xModifier = (isVertical * uStrokeWidth * aCorner.z / 2.0) + xDisplacement;
-        float yModifier = isHorizontal * uStrokeWidth * aCorner.z / 2.0;
-        `
+        float yModifier = isHorizontal * uStrokeWidth * aCorner.z / 2.0;`
 };


### PR DESCRIPTION
Adds `definedAttribute` to all WebGL series and discards undefined elements in the `fragmentShader`.

This solves #1412 

This can cause inconsistencies in rendering between SVG/Canvas implementations and WebGL implementations, for example if the index is used for the cross value (as seen below).

Canvas rendering:
![image](https://user-images.githubusercontent.com/26673042/73764806-806e3380-476b-11ea-9264-25b8170f8843.png)

WebGL rendering:
![image](https://user-images.githubusercontent.com/26673042/73764872-94b23080-476b-11ea-82fa-4ce6c224aac1.png)
