### PR TITLE
feat: add webgl and canvas plot area example

### DIFF
--- a/examples/svg-canvas-and-webgl-chart/README.md
+++ b/examples/svg-canvas-and-webgl-chart/README.md
@@ -1,0 +1,3 @@
+# Webgl and Canvas Plot
+
+This example demonstrates how a Webgl series and a Canvas series can be rendered together by drawing a Webgl candlestick series with a Canvas gridline series.

--- a/examples/svg-canvas-and-webgl-chart/index.html
+++ b/examples/svg-canvas-and-webgl-chart/index.html
@@ -1,0 +1,24 @@
+<html>
+
+<head>
+	<script src="../../node_modules/seedrandom/seedrandom.js"></script>
+	<script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <style>
+        body {
+            display: flex;
+        }
+
+        body>* {
+            flex: auto;
+        }
+    </style>
+</head>
+
+<body>
+	<div id="chart"></div>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/svg-canvas-and-webgl-chart/index.js
+++ b/examples/svg-canvas-and-webgl-chart/index.js
@@ -1,0 +1,28 @@
+const data = fc.randomFinancial()(100);
+
+const xScale = d3
+    .scaleTime()
+    .domain(fc.extentDate().accessors([d => d.date])(data));
+
+const yScale = d3
+    .scaleLinear()
+    .domain(fc.extentLinear().accessors([d => d.high, d => d.low])(data));
+
+const candlestick = fc.seriesWebglCandlestick();
+
+const gridline = fc.annotationCanvasGridline();
+
+const lowLine = fc
+    .seriesSvgLine()
+    .crossValue(d => d.date)
+    .mainValue(d => d.low);
+
+const chart = fc
+    .chartCartesian(xScale, yScale)
+    .webglPlotArea(candlestick)
+    .canvasPlotArea(gridline)
+    .svgPlotArea(lowLine);
+
+d3.select('#chart')
+    .datum(data)
+    .call(chart);


### PR DESCRIPTION
Adds a chart demonstrating how to use both `webglPlotArea` and `canvasPlotArea` together.

This resolves #1438 