### PR TITLE
refactor: glScales take identifier and component arguments

### DIFF
--- a/packages/d3fc-webgl/src/scale/glScaleBase.js
+++ b/packages/d3fc-webgl/src/scale/glScaleBase.js
@@ -1,7 +1,6 @@
 export default () => {
     let domain = [0, 1];
     let range = [-1, 1];
-    let coordinate = 0;
 
     const base = () => {};
 
@@ -18,14 +17,6 @@ export default () => {
             return range;
         }
         range = args[0];
-        return base;
-    };
-
-    base.coordinate = (...args) => {
-        if (!args.length) {
-            return coordinate;
-        }
-        coordinate = args[0];
         return base;
     };
 

--- a/packages/d3fc-webgl/src/series/glArea.js
+++ b/packages/d3fc-webgl/src/series/glArea.js
@@ -64,10 +64,8 @@ export default () => {
             .vertexShader(shaderBuilder.vertex())
             .fragmentShader(shaderBuilder.fragment());
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         decorate(program);
 

--- a/packages/d3fc-webgl/src/series/glBar.js
+++ b/packages/d3fc-webgl/src/series/glBar.js
@@ -76,10 +76,8 @@ export default () => {
             .fragmentShader(shader.fragment())
             .mode(drawModes.TRIANGLES);
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         program.vertexShader().appendBody(`
             gl_Position.x += xModifier / uScreen.x * 2.0;

--- a/packages/d3fc-webgl/src/series/glBoxPlot.js
+++ b/packages/d3fc-webgl/src/series/glBoxPlot.js
@@ -213,10 +213,8 @@ export default () => {
             .fragmentShader(shader.fragment())
             .mode(drawModes.TRIANGLES);
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         lineWidth(program);
 

--- a/packages/d3fc-webgl/src/series/glCandlestick.js
+++ b/packages/d3fc-webgl/src/series/glCandlestick.js
@@ -88,10 +88,8 @@ export default () => {
             .fragmentShader(shaderBuilder.fragment())
             .mode(drawModes.TRIANGLES);
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         lineWidth(program);
 

--- a/packages/d3fc-webgl/src/series/glErrorBar.js
+++ b/packages/d3fc-webgl/src/series/glErrorBar.js
@@ -94,10 +94,8 @@ export default () => {
             .fragmentShader(shader.fragment())
             .mode(drawModes.TRIANGLES);
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         lineWidth(program);
 

--- a/packages/d3fc-webgl/src/series/glLine.js
+++ b/packages/d3fc-webgl/src/series/glLine.js
@@ -73,16 +73,14 @@ export default () => {
             .vertexShader(shaderBuilder.vertex())
             .fragmentShader(shaderBuilder.fragment());
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
-        xScale.scaleComponent(program, 'next');
-        yScale.scaleComponent(program, 'next');
-        xScale.scaleComponent(program, 'prev');
-        yScale.scaleComponent(program, 'prev');
-        xScale.scaleComponent(program, 'prevPrev');
-        yScale.scaleComponent(program, 'prevPrev');
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
+        xScale(program, 'next', 0);
+        yScale(program, 'next', 1);
+        xScale(program, 'prev', 0);
+        yScale(program, 'prev', 1);
+        xScale(program, 'prevPrev', 0);
+        yScale(program, 'prevPrev', 1);
 
         program
             .vertexShader()

--- a/packages/d3fc-webgl/src/series/glOhlc.js
+++ b/packages/d3fc-webgl/src/series/glOhlc.js
@@ -100,10 +100,8 @@ export default () => {
             .fragmentShader(shaderBuilder.fragment())
             .mode(drawModes.TRIANGLES);
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         lineWidth(program);
 

--- a/packages/d3fc-webgl/src/series/glPoint.js
+++ b/packages/d3fc-webgl/src/series/glPoint.js
@@ -34,10 +34,8 @@ export default () => {
             .attribute('aSize', sizeAttribute)
             .attribute('aDefined', definedAttribute);
 
-        xScale.coordinate(0);
-        xScale(program);
-        yScale.coordinate(1);
-        yScale(program);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
 
         decorate(program);
 


### PR DESCRIPTION
Refactors `glScaleX` to add an identifier and component argument, this removes the `coordinate` property and `scaleComponent` function.

New use looks like:
```javascript
xScale(program, 'gl_Position', 0);
yScale(program, 'gl_Position', 1);
```

This resolves #1362 