### PR TITLE
d3fc-pointer - Set package.json main entry to build/d3fc-pointer.js

### DIFF
--- a/packages/d3fc-pointer/package.json
+++ b/packages/d3fc-pointer/package.json
@@ -2,7 +2,7 @@
   "name": "@d3fc/d3fc-pointer",
   "version": "2.0.11",
   "description": "Component which emits the current mouse or touch position over a selection",
-  "main": "index.js",
+  "main": "build/d3fc-pointer.js",
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
     "test": "npx jasmine --config=../../scripts/jasmine.json"


### PR DESCRIPTION
I was having trouble importing the pointer in my project via

```import { pointer } from '@d3fc/d3fc-pointer';```

When I compared d3fc-pointer to other d3fc packages, I noticed this minor difference, which in turn solved my import problem.