### PR TITLE
hack: comment out blocking state sync calls

### DIFF
--- a/packages/d3fc-webgl/README.md
+++ b/packages/d3fc-webgl/README.md
@@ -836,6 +836,10 @@ If *mode* is specified, sets the mode and returns this builder. If *mode* is not
 
 *mode* must be a WebGL draw mode, modes supported by `webglProgramBuilder` are `WebGLRenderingContext.POINTS` and `WebGLRenderingContext.TRIANGLES`.
 
+<a name="webglProgramBuilder_debug" href="#webglProgramBuilder_debug">#</a> *webglProgramBuilder*.**debug**(*debug*)
+
+If *debug* is specified, enables or disables additional verfication checks and error logging. This is very useful when working with custom shaders or debugging `INVALID_OPERATION` messages. However, it should not be enabled in production as the checks serverly impact rendering performance. If *debug* is not specified, returns the current debug setting.
+
 ### Symbol Mapper
 
 <a name="webglSymbolMapper" href="#webglSymbolMapper">#</a> fc.**webglSymbolMapper**(*symbol*)

--- a/packages/d3fc-webgl/src/buffer/baseAttribute.js
+++ b/packages/d3fc-webgl/src/buffer/baseAttribute.js
@@ -13,7 +13,7 @@ export default () => {
     const baseAttribute = programBuilder => {
         const gl = programBuilder.context();
 
-        if (buffer == null || !gl.isBuffer(buffer)) {
+        if (buffer == null) {
             buffer = gl.createBuffer();
         }
 

--- a/packages/d3fc-webgl/src/buffer/elementIndices.js
+++ b/packages/d3fc-webgl/src/buffer/elementIndices.js
@@ -6,7 +6,7 @@ export default initialData => {
     const base = programBuilder => {
         const gl = programBuilder.context();
 
-        if (buffer == null || !gl.isBuffer(buffer)) {
+        if (buffer == null) {
             buffer = gl.createBuffer();
         }
         gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffer);

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -9,6 +9,7 @@ export default () => {
     let fragmentShader = null;
     let mode = drawModes.TRIANGLES;
     let buffers = bufferBuilder();
+    let debug = false;
 
     const build = count => {
         const vertexShaderSource = vertexShader();
@@ -87,6 +88,14 @@ export default () => {
         return build;
     };
 
+    build.debug = (...args) => {
+        if (!args.length) {
+            return debug;
+        }
+        debug = args[0];
+        return build;
+    };
+
     return build;
 
     function newProgram(program, vertexShader, fragmentShader) {
@@ -119,7 +128,10 @@ export default () => {
         context.attachShader(program, fragmentShader);
         context.linkProgram(program);
 
-        if (!context.getProgramParameter(program, context.LINK_STATUS)) {
+        if (
+            debug &&
+            !context.getProgramParameter(program, context.LINK_STATUS)
+        ) {
             const message = context.getProgramInfoLog(program);
             context.deleteProgram(program);
             throw new Error(`Failed to link program : ${message}
@@ -135,7 +147,10 @@ export default () => {
         context.shaderSource(shader, source);
         context.compileShader(shader);
 
-        if (!context.getShaderParameter(shader, context.COMPILE_STATUS)) {
+        if (
+            debug &&
+            !context.getShaderParameter(shader, context.COMPILE_STATUS)
+        ) {
             const message = context.getShaderInfoLog(shader);
             context.deleteShader(shader);
             throw new Error(`Failed to compile shader : ${message}


### PR DESCRIPTION
Performance test results -

```
 FAIL  series-webgl-line/__tests__/index.js (8.805s)
  ● should have consistent performance

    Expected 19.90499997433896 +/- 5.9952499987169485 for "draw-duration-1" but got 5.6683333435406285

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
      at Object.<anonymous> (series-webgl-line/__tests__/index.js:4:5)

  ● should have consistent performance

    Expected 12.064999997771034 +/- 5.603249999888551 for "draw-duration-2" but got 4.534999995181958

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
      at Object.<anonymous> (series-webgl-line/__tests__/index.js:4:5)

  ● should have consistent performance

    Expected 12.31666667930161 +/- 5.615833333965081 for "draw-duration-3" but got 4.933333334823449

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
      at Object.<anonymous> (series-webgl-line/__tests__/index.js:4:5)

  ● should have consistent performance

    Expected 12.005000025965273 +/- 5.600250001298264 for "draw-duration-4" but got 4.066666646394879

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
      at Object.<anonymous> (series-webgl-line/__tests__/index.js:4:5)

  ● should have consistent performance

    Expected 11.341666686348617 +/- 5.567083334317431 for "draw-duration-5" but got 5.021666661680986

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
      at Object.<anonymous> (series-webgl-line/__tests__/index.js:4:5)

  ● should have consistent performance

    Expected 13.134999996206412 +/- 5.65674999981032 for "draw-duration-6" but got 4.36333332133169

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
      at Object.<anonymous> (series-webgl-line/__tests__/index.js:4:5)

 › 6 snapshots failed.
 PASS  series-webgl-point/__tests__/index.js
 FAIL  series-webgl-area/__tests__/index.js
  ● should have consistent performance

    Expected 39.2233333356368 +/- 6.96116666678184 for "draw-duration-0" but got 31.398333337468404

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
          at runMicrotasks (<anonymous>)
      at Object.<anonymous> (series-webgl-area/__tests__/index.js:4:5)

  ● should have consistent performance

    Expected 15.940000012051314 +/- 5.797000000602566 for "draw-duration-1" but got 6.981666684926798

      28 |     }
      29 |     Object.entries(averages).forEach(([name, { sum, count }]) => {
    > 30 |         expect(sum / count).toMatchPerformanceSnapshot(name);
         |                             ^
      31 |     });
      32 |     return { pass: true, message: () => '' };
      33 | };

      at toMatchPerformanceSnapshot (__helpers__/toHaveConsistentPerformance.js:30:29)
          at Array.forEach (<anonymous>)
      at Object.forEach (__helpers__/toHaveConsistentPerformance.js:29:30)
          at runMicrotasks (<anonymous>)
      at Object.<anonymous> (series-webgl-area/__tests__/index.js:4:5)

 › 2 snapshots failed.
 PASS  series-webgl-bar/__tests__/index.js

Snapshot Summary
 › 8 snapshots failed from 2 test suites. Inspect your code changes or press `u` to update them.

Test Suites: 2 failed, 2 passed, 4 total
Tests:       2 failed, 4 skipped, 2 passed, 8 total
Snapshots:   8 failed, 23 passed, 31 total
Time:        15.188s
Ran all test suites with tests matching "perform".
```