### PR TITLE
refactor: change previous/current naming for line and area

### DIFF
--- a/packages/d3fc-series/src/webgl/area.js
+++ b/packages/d3fc-series/src/webgl/area.js
@@ -11,23 +11,23 @@ import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
 export default () => {
     const base = xyBase();
 
-    const crossPreviousValueAttribute = webglAdjacentElementAttribute(0, 1);
-    const crossValueAttribute = crossPreviousValueAttribute.offset(1);
-    const mainPreviousValueAttribute = webglAdjacentElementAttribute(0, 1);
-    const mainValueAttribute = mainPreviousValueAttribute.offset(1);
-    const basePreviousValueAttribute = webglAdjacentElementAttribute(0, 1);
-    const baseValueAttribute = basePreviousValueAttribute.offset(1);
+    const crossValueAttribute = webglAdjacentElementAttribute(0, 1);
+    const crossNextValueAttribute = crossValueAttribute.offset(1);
+    const mainValueAttribute = webglAdjacentElementAttribute(0, 1);
+    const mainNextValueAttribute = mainValueAttribute.offset(1);
+    const baseValueAttribute = webglAdjacentElementAttribute(0, 1);
+    const baseNextValueAttribute = baseValueAttribute.offset(1);
     const definedAttribute = webglAdjacentElementAttribute(0, 1)
         .type(webglTypes.UNSIGNED_BYTE);
     const definedNextAttribute = definedAttribute.offset(1);
 
     const draw = webglSeriesArea()
         .crossValueAttribute(crossValueAttribute)
-        .crossPreviousValueAttribute(crossPreviousValueAttribute)
+        .crossNextValueAttribute(crossNextValueAttribute)
         .mainValueAttribute(mainValueAttribute)
-        .mainPreviousValueAttribute(mainPreviousValueAttribute)
+        .mainNextValueAttribute(mainNextValueAttribute)
         .baseValueAttribute(baseValueAttribute)
-        .basePreviousValueAttribute(basePreviousValueAttribute)
+        .baseNextValueAttribute(baseNextValueAttribute)
         .definedAttribute(definedAttribute)
         .definedNextAttribute(definedNextAttribute);
 
@@ -45,9 +45,9 @@ export default () => {
         if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
             previousData = data;
 
-            crossPreviousValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-            mainPreviousValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
-            basePreviousValueAttribute.value((d, i) => yScale.scale(base.baseValue()(d, i))).data(data);
+            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+            mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
+            baseValueAttribute.value((d, i) => yScale.scale(base.baseValue()(d, i))).data(data);
             definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
         }
 

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -11,14 +11,14 @@ import { rebindAll, exclude, rebind } from '@d3fc/d3fc-rebind';
 export default () => {
     const base = xyBase();
 
-    const crossPreviousValueAttribute = webglAdjacentElementAttribute(-1, 2);
-    const crossValueAttribute = crossPreviousValueAttribute.offset(1);
-    const crossNextValueAttribute = crossPreviousValueAttribute.offset(2);
-    const crossPreviousPreviousValueAttribute = crossPreviousValueAttribute.offset(-1);
-    const mainPreviousValueAttribute = webglAdjacentElementAttribute(-1, 2);
-    const mainValueAttribute = mainPreviousValueAttribute.offset(1);
-    const mainNextValueAttribute = mainPreviousValueAttribute.offset(2);
-    const mainPreviousPreviousValueAttribute = mainPreviousValueAttribute.offset(-1);
+    const crossValueAttribute = webglAdjacentElementAttribute(-1, 2);
+    const crossPreviousValueAttribute = crossValueAttribute.offset(-1);
+    const crossNextValueAttribute = crossValueAttribute.offset(1);
+    const crossNextNextValueAttribute = crossValueAttribute.offset(2);
+    const mainValueAttribute = webglAdjacentElementAttribute(-1, 2);
+    const mainPreviousValueAttribute = mainValueAttribute.offset(-1);
+    const mainNextValueAttribute = mainValueAttribute.offset(1);
+    const mainNextNextValueAttribute = mainValueAttribute.offset(2);
     const definedAttribute = webglAdjacentElementAttribute(0, 1).type(webglTypes.UNSIGNED_BYTE);
     const definedNextAttribute = definedAttribute.offset(1);
 
@@ -26,11 +26,11 @@ export default () => {
         .crossPreviousValueAttribute(crossPreviousValueAttribute)
         .crossValueAttribute(crossValueAttribute)
         .crossNextValueAttribute(crossNextValueAttribute)
-        .crossPreviousPreviousValueAttribute(crossPreviousPreviousValueAttribute)
+        .crossNextNextValueAttribute(crossNextNextValueAttribute)
         .mainPreviousValueAttribute(mainPreviousValueAttribute)
         .mainValueAttribute(mainValueAttribute)
         .mainNextValueAttribute(mainNextValueAttribute)
-        .mainPreviousPreviousValueAttribute(mainPreviousPreviousValueAttribute)
+        .mainNextNextValueAttribute(mainNextNextValueAttribute)
         .definedAttribute(definedAttribute)
         .definedNextAttribute(definedNextAttribute);
 
@@ -45,11 +45,11 @@ export default () => {
             previousData = data;
 
             if (base.orient() === 'vertical') {
-                crossPreviousValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-                mainPreviousValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
+                crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+                mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
             } else {
-                crossPreviousValueAttribute.value((d, i) => xScale.scale(base.mainValue()(d, i))).data(data);
-                mainPreviousValueAttribute.value((d, i) => yScale.scale(base.crossValue()(d, i))).data(data);
+                crossValueAttribute.value((d, i) => xScale.scale(base.mainValue()(d, i))).data(data);
+                mainValueAttribute.value((d, i) => yScale.scale(base.crossValue()(d, i))).data(data);
             }
             definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
         }

--- a/packages/d3fc-webgl/README.md
+++ b/packages/d3fc-webgl/README.md
@@ -93,25 +93,25 @@ Used to construct a new WebGL Area series.
 
 If *attribute* is specified, sets the cross value attribute and returns this series. If *attribute* is not specified, returns the current cross value attribute.
 
-<a name="webglSeriesArea_crossPreviousValueAttribute" href="#webglSeriesArea_crossPreviousValueAttribute">#</a> *webglSeriesArea*.**crossPreviousValueAttribute**(*attribute*)
+<a name="webglSeriesArea_crossNextValueAttribute" href="#webglSeriesArea_crossNextValueAttribute">#</a> *webglSeriesArea*.**crossNextValueAttribute**(*attribute*)
 
-If *attribute* is specified, sets the cross previous value attribute and returns this series. If *attribute* is not specified, returns the current cross previous value attribute.
+If *attribute* is specified, sets the cross next value attribute and returns this series. If *attribute* is not specified, returns the current cross next value attribute.
 
 <a name="webglSeriesArea_mainValueAttribute" href="#webglSeriesArea_mainValueAttribute">#</a> *webglSeriesArea*.**mainValueAttribute**(*attribute*)
 
 If *attribute* is specified, sets the main value attribute and returns this series. If *attribute* is not specified, returns the current main value attribute.
 
-<a name="webglSeriesArea_mainPreviousValueAttribute" href="#webglSeriesArea_mainPreviousValueAttribute">#</a> *webglSeriesArea*.**mainPreviousValueAttribute**(*attribute*)
+<a name="webglSeriesArea_mainNextValueAttribute" href="#webglSeriesArea_mainNextValueAttribute">#</a> *webglSeriesArea*.**mainNextValueAttribute**(*attribute*)
 
-If *attribute* is specified, sets the main previous value attribute and returns this series. If *attribute* is not specified, returns the current main previous value attribute.
+If *attribute* is specified, sets the main next value attribute and returns this series. If *attribute* is not specified, returns the current main next value attribute.
 
 <a name="webglSeriesArea_baseValueAttribute" href="#webglSeriesArea_baseValueAttribute">#</a> *webglSeriesArea*.**baseValueAttribute**(*attribute*)
 
 If *attribute* is specified, sets the base value attribute and returns this series. If *attribute* is not specified, returns the current base value attribute.
 
-<a name="webglSeriesArea_basePreviousValueAttribute" href="#webglSeriesArea_basePreviousValueAttribute">#</a> *webglSeriesArea*.**basePreviousValueAttribute**(*attribute*)
+<a name="webglSeriesArea_baseNextValueAttribute" href="#webglSeriesArea_baseNextValueAttribute">#</a> *webglSeriesArea*.**baseNextValueAttribute**(*attribute*)
 
-If *attribute* is specified, sets the base previous value attribute and returns this series. If *attribute* is not specified, returns the current base previous value attribute.
+If *attribute* is specified, sets the base next value attribute and returns this series. If *attribute* is not specified, returns the current base next value attribute.
 
 <a name="webglSeriesArea_definedNextAttribute" href="#webglSeriesArea_definedNextAttribute">#</a> *webglSeriesArea*.**definedNextAttribute**(*attribute*)
 
@@ -283,9 +283,9 @@ If *attribute* is specified, sets the cross value attribute and returns this ser
 
 If *attribute* is specified, sets the cross next value attribute and returns this series. If *attribute* is not specified, returns the current cross next value attribute.
 
-<a name="webglSeriesLine_crossPreviousPreviousValueAttribute" href="#webglSeriesLine_crossPreviousPreviousValueAttribute">#</a> *webglSeriesLine*.**crossPreviousPreviousValueAttribute**(*attribute*)
+<a name="webglSeriesLine_crossNextNextValueAttribute" href="#webglSeriesLine_crossNextNextValueAttribute">#</a> *webglSeriesLine*.**crossNextNextValueAttribute**(*attribute*)
 
-If *attribute* is specified, sets the cross previous previous value attribute and returns this series. If *attribute* is not specified, returns the current cross previous previous value attribute.
+If *attribute* is specified, sets the cross next next value attribute and returns this series. If *attribute* is not specified, returns the current cross next next value attribute.
 
 <a name="webglSeriesLine_mainPreviousValueAttribute" href="#webglSeriesLine_mainPreviousValueAttribute">#</a> *webglSeriesLine*.**mainPreviousValueAttribute**(*attribute*)
 
@@ -299,9 +299,9 @@ If *attribute* is specified, sets the main value attribute and returns this seri
 
 If *attribute* is specified, sets the main next value attribute and returns this series. If *attribute* is not specified, returns the current main next value attribute.
 
-<a name="webglSeriesLine_mainPreviousPreviousValueAttribute" href="#webglSeriesLine_mainPreviousPreviousValueAttribute">#</a> *webglSeriesLine*.**mainPreviousPreviousValueAttribute**(*attribute*)
+<a name="webglSeriesLine_mainNextNextValueAttribute" href="#webglSeriesLine_mainNextNextValueAttribute">#</a> *webglSeriesLine*.**mainNextNextValueAttribute**(*attribute*)
 
-If *attribute* is specified, sets the main previous previous value attribute and returns this series. If *attribute* is not specified, returns the current main previous previous value attribute.
+If *attribute* is specified, sets the main next next value attribute and returns this series. If *attribute* is not specified, returns the current main next next value attribute.
 
 <a name="webglSeriesLine_definedNextAttribute" href="#webglSeriesLine_definedNextAttribute">#</a> *webglSeriesLine*.**definedNextAttribute**(*attribute*)
 

--- a/packages/d3fc-webgl/src/series/area.js
+++ b/packages/d3fc-webgl/src/series/area.js
@@ -79,10 +79,10 @@ export default () => {
     );
     rebindCurry(
         draw,
-        'crossPreviousValueAttribute',
+        'crossNextValueAttribute',
         program.buffers(),
         'attribute',
-        'aCrossPrevValue'
+        'aCrossNextValue'
     );
     rebindCurry(
         draw,
@@ -93,10 +93,10 @@ export default () => {
     );
     rebindCurry(
         draw,
-        'mainPreviousValueAttribute',
+        'mainNextValueAttribute',
         program.buffers(),
         'attribute',
-        'aMainPrevValue'
+        'aMainNextValue'
     );
     rebindCurry(
         draw,
@@ -107,10 +107,10 @@ export default () => {
     );
     rebindCurry(
         draw,
-        'basePreviousValueAttribute',
+        'baseNextValueAttribute',
         program.buffers(),
         'attribute',
-        'aBasePrevValue'
+        'aBaseNextValue'
     );
     rebindCurry(
         draw,

--- a/packages/d3fc-webgl/src/series/line.js
+++ b/packages/d3fc-webgl/src/series/line.js
@@ -39,14 +39,14 @@ export default () => {
             .vertexShader(shaderBuilder.vertex())
             .fragmentShader(shaderBuilder.fragment());
 
-        xScale(program, 'gl_Position', 0);
-        yScale(program, 'gl_Position', 1);
-        xScale(program, 'next', 0);
-        yScale(program, 'next', 1);
         xScale(program, 'prev', 0);
         yScale(program, 'prev', 1);
-        xScale(program, 'prevPrev', 0);
-        yScale(program, 'prevPrev', 1);
+        xScale(program, 'curr', 0);
+        yScale(program, 'curr', 1);
+        xScale(program, 'gl_Position', 0);
+        yScale(program, 'gl_Position', 1);
+        xScale(program, 'nextNext', 0);
+        yScale(program, 'nextNext', 1);
 
         program
             .vertexShader()
@@ -108,10 +108,10 @@ export default () => {
     );
     rebindCurry(
         draw,
-        'crossPreviousPreviousValueAttribute',
+        'crossNextNextValueAttribute',
         program.buffers(),
         'attribute',
-        'aCrossPrevPrevValue'
+        'aCrossNextNextValue'
     );
     rebindCurry(
         draw,
@@ -136,10 +136,10 @@ export default () => {
     );
     rebindCurry(
         draw,
-        'mainPreviousPreviousValueAttribute',
+        'mainNextNextValueAttribute',
         program.buffers(),
         'attribute',
-        'aMainPrevPrevValue'
+        'aMainNextNextValue'
     );
     rebindCurry(
         draw,

--- a/packages/d3fc-webgl/test/shaders/line/shaderSpec.js
+++ b/packages/d3fc-webgl/test/shaders/line/shaderSpec.js
@@ -21,14 +21,14 @@ describe('glLine', () => {
     it('correctly positions the first point in a series', () => {
         const attributes = {
             aCorner: [-1, 0, 0],
-            aCrossValue: 1,
-            aMainValue: 5,
-            aCrossNextValue: 2,
-            aMainNextValue: 4,
+            aCrossNextValue: 1,
+            aMainNextValue: 5,
+            aCrossNextNextValue: 2,
+            aMainNextNextValue: 4,
+            aCrossValue: 0,
+            aMainValue: 4,
             aCrossPrevValue: 0,
             aMainPrevValue: 4,
-            aCrossPrevPrevValue: 0,
-            aMainPrevPrevValue: 4,
             aDefined: 1
         };
 
@@ -42,14 +42,14 @@ describe('glLine', () => {
     it('correctly positions a point in the middle of a series', () => {
         const attributes = {
             aCorner: [-1, 0, 0],
-            aCrossValue: 2,
-            aMainValue: 4,
-            aCrossNextValue: 3,
-            aMainNextValue: 5,
-            aCrossPrevValue: 1,
-            aMainPrevValue: 5,
-            aCrossPrevPrevValue: 0,
-            aMainPrevPrevValue: 4,
+            aCrossNextValue: 2,
+            aMainNextValue: 4,
+            aCrossNextNextValue: 3,
+            aMainNextNextValue: 5,
+            aCrossValue: 1,
+            aMainValue: 5,
+            aCrossPrevValue: 0,
+            aMainPrevValue: 4,
             aDefined: 1
         };
 
@@ -63,14 +63,14 @@ describe('glLine', () => {
     it('correctly positions the last point in a series', () => {
         const attributes = {
             aCorner: [-1, 0, 0],
-            aCrossValue: 8,
-            aMainValue: 5,
             aCrossNextValue: 8,
             aMainNextValue: 5,
-            aCrossPrevValue: 7,
-            aMainPrevValue: 4,
-            aCrossPrevPrevValue: 6,
-            aMainPrevPrevValue: 5,
+            aCrossNextNextValue: 8,
+            aMainNextNextValue: 5,
+            aCrossValue: 7,
+            aMainValue: 4,
+            aCrossPrevValue: 6,
+            aMainPrevValue: 5,
             aDefined: 1
         };
 


### PR DESCRIPTION
Updates the naming used for `line` and `area` to better reflect the data and how the drawing is performed.

Before this change the current data point being processed would be set to the 'previous value' and the next data point would be set to the 'current value'. This PR makes the current data point being processed the 'current value'.

The relevant docs have also been updated to reflect this change.