### PR TITLE
fix: remove broken webgl boxplot fill

### DIFF
--- a/packages/d3fc-webgl/src/series/boxPlot.js
+++ b/packages/d3fc-webgl/src/series/boxPlot.js
@@ -112,13 +112,6 @@ export default () => {
         .buffers()
         .elementIndices(
             elementIndices([
-                // Fill
-                21,
-                22,
-                25,
-                22,
-                25,
-                26,
                 // Top cap line
                 0,
                 1,

--- a/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
@@ -106,14 +106,10 @@ export const area = {
 export const boxPlot = {
     header: `
         varying float vDefined;
-        varying float vCanFill;
     `,
     body: `
-        float canFill = clamp(vCanFill, 0.0, 1.0);
-        float canStroke = 1.0 - vCanFill;
-
-        vec4 defaultFillColor = vec4(0.86, 0.86, 0.86, 1.0);
-        gl_FragColor = (canFill * defaultFillColor) + (canStroke * gl_FragColor);
+        float canFill = 0.0;
+        float canStroke = 1.0;
 
         if (vDefined < 0.5) {
             discard;

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -367,11 +367,9 @@ export const boxPlot = {
         uniform float uStrokeWidth;
 
         varying float vDefined;
-        varying float vCanFill;
     `,
     body: `
         vDefined = aDefined;
-        vCanFill = abs(aCorner.x) * (1.0 - aCorner.w) * aCorner.z;
         float isExtremeY = sign(abs(aCorner.y) - 2.0) + 1.0;
         float isNotExtremeY = 1.0 - isExtremeY;
 


### PR DESCRIPTION
Removed broken colouring.

![webgl-boxplot](https://user-images.githubusercontent.com/6894766/76541274-36b7ed80-647b-11ea-9475-c504ce8036f9.png)
