### PR TITLE
add scaleMapper property to series & optimise performance

### DIFF
--- a/packages/d3fc-series/README.md
+++ b/packages/d3fc-series/README.md
@@ -429,6 +429,20 @@ The SVG and canvas implementations do not support this property.
 
 If *width* is specified, sets the line width and returns this series. If *width* is not specified, returns the current line width.
 
+<a name="seriesLine_equals" href="#seriesLine_equals">#</a> *seriesLine*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesLine_scaleMapper" href="#seriesLine_scaleMapper">#</a> *seriesLine*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
+
 ### Point
 
 ![](screenshots/point.png)
@@ -475,6 +489,20 @@ The SVG implementation does not support this property.
 
 If *ctx* is specified, sets the canvas context and returns this series. If *ctx* is not specified, returns the current context.
 
+<a name="seriesPoint_equals" href="#seriesPoint_equals">#</a> *seriesPoint*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesPoint_scaleMapper" href="#seriesPoint_scaleMapper">#</a> *seriesPoint*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
+
 ### Area
 
 ![](screenshots/area.png)
@@ -516,6 +544,20 @@ The SVG implementation does not support this property.
 
 If *ctx* is specified, sets the canvas context and returns this series. If *ctx* is not specified, returns the current context.
 
+<a name="seriesArea_equals" href="#seriesArea_equals">#</a> *seriesArea*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesArea_scaleMapper" href="#seriesArea_scaleMapper">#</a> *seriesArea*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
+
 ### Bar
 
 ![](screenshots/bar.png)
@@ -555,6 +597,19 @@ The SVG implementation does not support this property.
 
 If *ctx* is specified, sets the canvas context and returns this series. If *ctx* is not specified, returns the current context.
 
+<a name="seriesBar_equals" href="#seriesBar_equals">#</a> *seriesBar*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesBar_scaleMapper" href="#seriesBar_scaleMapper">#</a> *seriesBar*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
 
 ### Candlestick
 
@@ -599,6 +654,20 @@ The SVG and canvas implementations do not support this property.
 
 If *width* is specified, sets the line width and returns this series. If *width* is not specified, returns the current line width.
 
+<a name="seriesCandlestick_equals" href="#seriesCandlestick_equals">#</a> *seriesCandlestick*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesCandlestick_scaleMapper" href="#seriesCandlestick_scaleMapper">#</a> *seriesCandlestick*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
+
 ### OHLC
 
 ![](screenshots/ohlc.png)
@@ -609,7 +678,7 @@ If *width* is specified, sets the line width and returns this series. If *width*
 
 Constructs a new OHLC renderer for canvas, WebGL or SVG.
 
-### Common properties
+#### Common properties
 
 <a name="seriesOhlc_crossValue" href="#seriesOhlc_crossValue">#</a> *seriesOhlc*.**crossValue**(*accessorFunc*)  
 <a name="seriesOhlc_highValue" href="#seriesOhlc_highValue">#</a> *seriesOhlc*.**highValue**(*accessorFunc*)  
@@ -643,6 +712,20 @@ If *ctx* is specified, sets the canvas context and returns this series. If *ctx*
 The SVG and canvas implementations do not support this property.
 
 If *width* is specified, sets the line width and returns this series. If *width* is not specified, returns the current line width.
+
+<a name="seriesOhlc_equals" href="#seriesOhlc_equals">#</a> *seriesOhlc*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesOhlc_scaleMapper" href="#seriesOhlc_scaleMapper">#</a> *seriesOhlc*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
 
 ### Boxplot
 
@@ -700,6 +783,20 @@ The SVG and canvas implementations do not support this property.
 
 If *width* is specified, sets the line width and returns this series. If *width* is not specified, returns the current line width.
 
+<a name="seriesBoxplot_equals" href="#seriesBoxplot_equals">#</a> *seriesBoxplot*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesBoxplot_scaleMapper" href="#seriesBoxplot_scaleMapper">#</a> *seriesBoxplot*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
+
 ### Errorbar
 
 ![](screenshots/errorbar.png)
@@ -748,6 +845,20 @@ If *ctx* is specified, sets the canvas context and returns this series. If *ctx*
 The SVG and canvas implementations do not support this property.
 
 If *width* is specified, sets the line width and returns this series. If *width* is not specified, returns the current line width.
+
+<a name="seriesErrorBar_equals" href="#seriesErrorBar_equals">#</a> *seriesErrorBar*.**equals**(*equals*)
+
+The SVG and canvas implementations do not support this property.
+
+If *equals* is specified, sets the equality function used to compare *previousData* with *data*. The result of this check is used to control whether the data is reprojected and rescaled. If *equals* is not specified, returns the current equality function which defaults to always returning false indicating the data has changed.
+
+<a name="seriesErrorBar_scaleMapper" href="#seriesErrorBar_scaleMapper">#</a> *seriesErrorBar*.**scaleMapper**(*scaleMapper*)
+
+The SVG and canvas implementations do not support this property.
+
+If *scaleMapper* is specified, sets the function used to map first the xScale and then the yScale onto matched pairs of JavaScript and WebGL implementations. If *equals* is not specified, returns the current scale mapper which defaults to [webglScaleMapper](https://github.com/d3fc/d3fc/packages/d3fc-webgl#webglScaleMapper).
+
+The returned JavaScript scale is equality checked using a reference comparison to determine whether the data needs to be rescaled. If the reference is the same as the previous render, the values associated with the scale are not rescaled.
 
 ### Heatmap
 

--- a/packages/d3fc-series/src/webgl/area.js
+++ b/packages/d3fc-series/src/webgl/area.js
@@ -31,6 +31,7 @@ export default () => {
         .definedNextAttribute(definedNextAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
@@ -40,8 +41,8 @@ export default () => {
             throw new Error(`Unsupported orientation ${base.orient()}`);
         }
 
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -71,6 +72,14 @@ export default () => {
             return equals;
         }
         equals = args[0];
+        return area;
+    };
+
+    area.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return area;
     };
 

--- a/packages/d3fc-series/src/webgl/area.js
+++ b/packages/d3fc-series/src/webgl/area.js
@@ -1,5 +1,4 @@
 import xyBase from '../xyBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglSeriesArea,
     webglAdjacentElementAttribute,
@@ -33,6 +32,8 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
 
     const area = (data) => {
         if (base.orient() !== 'vertical') {
@@ -41,14 +42,20 @@ export default () => {
 
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-
-            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-            mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
-            baseValueAttribute.value((d, i) => yScale.scale(base.baseValue()(d, i))).data(data);
             definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
+            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
+            baseValueAttribute.value((d, i) => yScale.scale(base.baseValue()(d, i))).data(data);
+            mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
         }
 
         draw

--- a/packages/d3fc-series/src/webgl/bar.js
+++ b/packages/d3fc-series/src/webgl/bar.js
@@ -24,6 +24,7 @@ export default () => {
         .definedAttribute(definedAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
@@ -33,8 +34,8 @@ export default () => {
             throw new Error(`Unsupported orientation ${base.orient()}`);
         }
 
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -64,6 +65,14 @@ export default () => {
             return equals;
         }
         equals = args[0];
+        return bar;
+    };
+
+    bar.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return bar;
     };
 

--- a/packages/d3fc-series/src/webgl/bar.js
+++ b/packages/d3fc-series/src/webgl/bar.js
@@ -1,5 +1,4 @@
 import xyBase from '../xyBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglSeriesBar,
     webglElementAttribute,
@@ -26,6 +25,8 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
 
     const bar = (data) => {
         if (base.orient() !== 'vertical') {
@@ -34,15 +35,21 @@ export default () => {
 
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-
-            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-            mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
-            baseValueAttribute.value((d, i) => yScale.scale(base.baseValue()(d, i))).data(data);
             bandwidthAttribute.value((d, i) => base.bandwidth()(d, i)).data(data);
             definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
+            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
+            baseValueAttribute.value((d, i) => yScale.scale(base.baseValue()(d, i))).data(data);
+            mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
         }
 
         draw.xScale(xScale.webglScale)

--- a/packages/d3fc-series/src/webgl/boxPlot.js
+++ b/packages/d3fc-series/src/webgl/boxPlot.js
@@ -1,5 +1,4 @@
 import boxPlotBase from '../boxPlotBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglSeriesBoxPlot,
     webglElementAttribute,
@@ -35,6 +34,8 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
     let cap = functor(20);
 
     const boxPlot = (data) => {
@@ -44,19 +45,25 @@ export default () => {
 
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-        
+            bandwidthAttribute.value((d, i) => base.bandwidth()(d, i)).data(data);
+            capAttribute.value((d, i) => cap(d, i)).data(data);
+            definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
             crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
             highValueAttribute.value((d, i) => yScale.scale(base.highValue()(d, i))).data(data);
             upperQuartileValueAttribute.value((d, i) => yScale.scale(base.upperQuartileValue()(d, i))).data(data);
             medianValueAttribute.value((d, i) => yScale.scale(base.medianValue()(d, i))).data(data);
             lowerQuartileValueAttribute.value((d, i) => yScale.scale(base.lowerQuartileValue()(d, i))).data(data);
             lowValueAttribute.value((d, i) => yScale.scale(base.lowValue()(d, i))).data(data);
-            bandwidthAttribute.value((d, i) => base.bandwidth()(d, i)).data(data);
-            capAttribute.value((d, i) => cap(d, i)).data(data);
-            definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
         }
 
         draw.xScale(xScale.webglScale)

--- a/packages/d3fc-series/src/webgl/boxPlot.js
+++ b/packages/d3fc-series/src/webgl/boxPlot.js
@@ -33,6 +33,7 @@ export default () => {
         .definedAttribute(definedAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
@@ -43,8 +44,8 @@ export default () => {
             throw new Error(`Unsupported orientation ${base.orient()}`);
         }
 
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -86,6 +87,14 @@ export default () => {
             return equals;
         }
         equals = args[0];
+        return boxPlot;
+    };
+
+    boxPlot.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return boxPlot;
     };
     

--- a/packages/d3fc-series/src/webgl/errorBar.js
+++ b/packages/d3fc-series/src/webgl/errorBar.js
@@ -1,5 +1,4 @@
 import errorBarBase from '../errorBarBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglSeriesErrorBar,
     webglElementAttribute,
@@ -26,23 +25,32 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
 
     const errorBar = (data) => {
         if (base.orient() !== 'vertical') {
             throw new Error(`Unsupported orientation ${base.orient()}`);
         }
 
+
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-
-            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-            highValueAttribute.value((d, i) => yScale.scale(base.highValue()(d, i))).data(data);
-            lowValueAttribute.value((d, i) => yScale.scale(base.lowValue()(d, i))).data(data);
             bandwidthAttribute.value((d, i) => base.bandwidth()(d, i)).data(data);
             definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
+            crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
+            highValueAttribute.value((d, i) => yScale.scale(base.highValue()(d, i))).data(data);
+            lowValueAttribute.value((d, i) => yScale.scale(base.lowValue()(d, i))).data(data);
         }
 
         draw.xScale(xScale.webglScale)

--- a/packages/d3fc-series/src/webgl/errorBar.js
+++ b/packages/d3fc-series/src/webgl/errorBar.js
@@ -24,6 +24,7 @@ export default () => {
         .definedAttribute(definedAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
@@ -34,8 +35,8 @@ export default () => {
         }
 
 
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -65,6 +66,14 @@ export default () => {
             return equals;
         }
         equals = args[0];
+        return errorBar;
+    };
+
+    errorBar.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return errorBar;
     };
 

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -1,5 +1,4 @@
 import xyBase from '../xyBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglSeriesLine,
     webglAdjacentElementAttribute,
@@ -36,22 +35,33 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
 
     const line = (data) => {
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-
+            definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
             if (base.orient() === 'vertical') {
                 crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-                mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
             } else {
                 crossValueAttribute.value((d, i) => xScale.scale(base.mainValue()(d, i))).data(data);
+            }
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
+            if (base.orient() === 'vertical') {
+                mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
+            } else {
                 mainValueAttribute.value((d, i) => yScale.scale(base.crossValue()(d, i))).data(data);
             }
-            definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
         }
 
         draw.xScale(xScale.webglScale)

--- a/packages/d3fc-series/src/webgl/line.js
+++ b/packages/d3fc-series/src/webgl/line.js
@@ -34,13 +34,14 @@ export default () => {
         .definedNextAttribute(definedNextAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
 
     const line = (data) => {
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -76,6 +77,14 @@ export default () => {
             return equals;
         }
         equals = args[0];
+        return line;
+    };
+
+    line.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return line;
     };
 

--- a/packages/d3fc-series/src/webgl/ohlcBase.js
+++ b/packages/d3fc-series/src/webgl/ohlcBase.js
@@ -27,13 +27,14 @@ export default (pathGenerator) => {
         .definedAttribute(definedAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
 
     const candlestick = (data) => {
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -65,6 +66,14 @@ export default (pathGenerator) => {
             return equals;
         }
         equals = args[0];
+        return candlestick;
+    };
+
+    candlestick.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return candlestick;
     };
 

--- a/packages/d3fc-series/src/webgl/ohlcBase.js
+++ b/packages/d3fc-series/src/webgl/ohlcBase.js
@@ -1,5 +1,4 @@
 import ohlcBase from '../ohlcBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglElementAttribute,
     webglScaleMapper,
@@ -29,21 +28,29 @@ export default (pathGenerator) => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
 
     const candlestick = (data) => {
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-
+            bandwidthAttribute.value((d, i) => base.bandwidth()(d, i)).data(data);
+            definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
             crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
             openValueAttribute.value((d, i) => yScale.scale(base.openValue()(d, i))).data(data);
             highValueAttribute.value((d, i) => yScale.scale(base.highValue()(d, i))).data(data);
             lowValueAttribute.value((d, i) => yScale.scale(base.lowValue()(d, i))).data(data);
             closeValueAttribute.value((d, i) => yScale.scale(base.closeValue()(d, i))).data(data);
-            bandwidthAttribute.value((d, i) => base.bandwidth()(d, i)).data(data);
-            definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
         }
 
         pathGenerator.xScale(xScale.webglScale)

--- a/packages/d3fc-series/src/webgl/point.js
+++ b/packages/d3fc-series/src/webgl/point.js
@@ -27,13 +27,14 @@ export default () => {
         .definedAttribute(definedAttribute);
 
     let equals = (previousData, data) => false;
+    let scaleMapper = webglScaleMapper;
     let previousData = [];
     let previousXScale = null;
     let previousYScale = null;
 
     const point = (data) => {
-        const xScale = webglScaleMapper(base.xScale());
-        const yScale = webglScaleMapper(base.yScale());
+        const xScale = scaleMapper(base.xScale());
+        const yScale = scaleMapper(base.yScale());
         const dataChanged = !equals(previousData, data);
 
         if (dataChanged) {
@@ -87,6 +88,14 @@ export default () => {
             return equals;
         }
         equals = args[0];
+        return point;
+    };
+
+    point.scaleMapper = (...args) => {
+        if (!args.length) {
+            return scaleMapper;
+        }
+        scaleMapper = args[0];
         return point;
     };
 

--- a/packages/d3fc-series/src/webgl/point.js
+++ b/packages/d3fc-series/src/webgl/point.js
@@ -1,6 +1,5 @@
 import { symbolCircle } from 'd3-shape';
 import xyBase from '../xyBase';
-import isIdentityScale from '../isIdentityScale';
 import {
     webglSeriesPoint,
     webglElementAttribute,
@@ -29,23 +28,34 @@ export default () => {
 
     let equals = (previousData, data) => false;
     let previousData = [];
+    let previousXScale = null;
+    let previousYScale = null;
 
     const point = (data) => {
         const xScale = webglScaleMapper(base.xScale());
         const yScale = webglScaleMapper(base.yScale());
+        const dataChanged = !equals(previousData, data);
 
-        if (!isIdentityScale(xScale.scale) || !isIdentityScale(yScale.scale) || !equals(previousData, data)) {
+        if (dataChanged) {
             previousData = data;
-
-            if (base.orient() === 'vertical') {
-                crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
-                mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
-            } else {
-                crossValueAttribute.value((d, i) => xScale.scale(base.mainValue()(d, i))).data(data);
-                mainValueAttribute.value((d, i) => yScale.scale(base.crossValue()(d, i))).data(data);
-            }
             sizeAttribute.value((d, i) => size(d, i)).data(data);
             definedAttribute.value((d, i) => base.defined()(d, i)).data(data);
+        }
+        if (dataChanged || xScale.scale !== previousXScale) {
+            previousXScale = xScale.scale;
+            if (base.orient() === 'vertical') {
+                crossValueAttribute.value((d, i) => xScale.scale(base.crossValue()(d, i))).data(data);
+            } else {
+                crossValueAttribute.value((d, i) => xScale.scale(base.mainValue()(d, i))).data(data);
+            }
+        }
+        if (dataChanged || yScale.scale !== previousYScale) {
+            previousYScale = yScale.scale;
+            if (base.orient() === 'vertical') {
+                mainValueAttribute.value((d, i) => yScale.scale(base.mainValue()(d, i))).data(data);
+            } else {
+                mainValueAttribute.value((d, i) => yScale.scale(base.crossValue()(d, i))).data(data);
+            }
         }
 
         draw.xScale(xScale.webglScale)

--- a/packages/d3fc-webgl/README.md
+++ b/packages/d3fc-webgl/README.md
@@ -745,12 +745,11 @@ If *range* is specified, sets the range and returns this scale. If *range* is no
 
 <a name="webglScaleMapper" href="#webglScaleMapper">#</a> fc.**webglScaleMapper**(*scale*)
 
-Used to map a [D3 Scale](https://github.com/d3/d3-scale#continuous-scales) (*scale*) to a WebGL equivalent, all relevant properties are copied across.
+Used to map a [D3 Scale](https://github.com/d3/d3-scale#continuous-scales) (*scale*) to a matched pair of JavaScript and WebGL scales with appropriate properties (e.g. `domain`) copied over. Returns an object containing two fields, `scale`, and `webglScale`.
 
-Returns an object containing two fields, `scale`, and `webglScale`.
+The JavaScript scale is guaranteed to be a pure function if the returned reference is equal to a previously returned reference.
 
-On a successful mapping the `scale` field will contain a [`d3.scaleIdentity`](https://github.com/d3/d3-scale#scaleIdentity) and the `webglScale` field will contain an appropriate WebGL scale.
-On an unsuccessful mapping the `scale` field will contain *scale* and the `webglScale` field will contain a [`webglScaleLinear`](#linear).
+As there is no reliable way to test for the type of a scale, this implementation is naive and may return non-optimal mappings.
 
 ### Shader Builder
 

--- a/packages/d3fc-webgl/src/buffer/baseAttribute.js
+++ b/packages/d3fc-webgl/src/buffer/baseAttribute.js
@@ -29,7 +29,9 @@ export default () => {
         gl.enableVertexAttribArray(location);
 
         const extInstancedArrays = programBuilder.extInstancedArrays();
-        extInstancedArrays.vertexAttribDivisorANGLE(location, divisor);
+        if (extInstancedArrays != null) {
+            extInstancedArrays.vertexAttribDivisorANGLE(location, divisor);
+        }
     };
 
     baseAttribute.location = (...args) => {

--- a/packages/d3fc-webgl/src/scale/scaleMapper.js
+++ b/packages/d3fc-webgl/src/scale/scaleMapper.js
@@ -16,18 +16,22 @@ const scaleLogCopy = scaleLog().copy.toString();
 const scalePowCopy = scalePow().copy.toString();
 const scaleTimeCopy = scaleTime().copy.toString();
 
+// always return the same reference to hint to consumers that
+// it is a pure function
+const identity = scaleIdentity();
+
 export default scale => {
     switch (scale.copy.toString()) {
         case scaleLinearCopy:
         case scaleTimeCopy: {
             return {
-                scale: scaleIdentity(),
+                scale: identity,
                 webglScale: linear().domain(scale.domain())
             };
         }
         case scaleLogCopy: {
             return {
-                scale: scaleIdentity(),
+                scale: identity,
                 webglScale: log()
                     .domain(scale.domain())
                     .base(scale.base())
@@ -35,15 +39,17 @@ export default scale => {
         }
         case scalePowCopy: {
             return {
-                scale: scaleIdentity(),
+                scale: identity,
                 webglScale: pow()
                     .domain(scale.domain())
                     .exponent(scale.exponent())
             };
         }
         default: {
+            // always return a copy of the scale to hint to consumers
+            // that it may be an impure function
             return {
-                scale,
+                scale: scale.copy(),
                 webglScale: linear().domain(scale.range())
             };
         }

--- a/packages/d3fc-webgl/src/series/point.js
+++ b/packages/d3fc-webgl/src/series/point.js
@@ -4,19 +4,9 @@ import circlePointShader from '../shaders/point/circle/baseShader';
 import drawModes from '../program/drawModes';
 import { rebind } from '@d3fc/d3fc-rebind';
 import rebindCurry from '../rebindCurry';
-import vertexAttribute from '../buffer/vertexAttribute';
-import elementIndices from '../buffer/elementIndices';
 
 export default () => {
     const program = programBuilder().mode(drawModes.POINTS);
-
-    // hack to allow a consistent instanced render path
-    const ignoredAttribute = vertexAttribute().data([0]);
-
-    program
-        .buffers()
-        .attribute('aIgnored', ignoredAttribute)
-        .elementIndices(elementIndices([0]));
 
     let xScale = baseScale();
     let yScale = baseScale();
@@ -24,14 +14,7 @@ export default () => {
     let decorate = () => {};
 
     const draw = numElements => {
-        program
-            .vertexShader(
-                type
-                    .vertex()
-                    .appendHeader('attribute float aIgnored;')
-                    .appendBody('gl_Position += aIgnored;')
-            )
-            .fragmentShader(type.fragment());
+        program.vertexShader(type.vertex()).fragmentShader(type.fragment());
 
         xScale(program, 'gl_Position', 0);
         yScale(program, 'gl_Position', 1);


### PR DESCRIPTION
Still to do -

* ~Add `scaleMapper` property to series~

Offers an alternative to #1492 which offers a route forward for #1491.

I debated for a long time whether `equals` & `scaleMapper` should be cascaded by `seriesWebglMulti` before realising it didn't exist. I'd come to the conclusion that it probably should be cascaded -

* `equals` - I think in most cases you'd want consistent behaviour across all series but if you didn't it would be possible to have a consistent check (e.g. `obj[Symbol.equals](other)`) and use `mapping` to mutate this value to have different behaviour per series
* `scaleMapper` - I can't see a use case for a different `scaleMapper` per series