### PR TITLE
wip: Streaming attribute

### DIFF
--- a/examples/series-webgl-point/index.js
+++ b/examples/series-webgl-point/index.js
@@ -1,4 +1,4 @@
-const data = fc.randomGeometricBrownianMotion().steps(1e4)(1);
+const data = fc.randomGeometricBrownianMotion().steps(1e5)(1);
 
 const extent = fc.extentLinear();
 
@@ -14,6 +14,19 @@ const gl = d3
     .node()
     .getContext('webgl');
 
+const mainValueAttribute = fc
+    .webglStreamingElementAttribute()
+    .value(() => 1)
+    .count(data.length);
+
+setInterval(() => {
+    mainValueAttribute.enqueue(
+        { length: 100 },
+        Math.floor(Math.random() * 1000) * 100
+    );
+    container.requestRedraw();
+}, 10);
+
 const series = fc
     .seriesWebglPoint()
     .xScale(xScale)
@@ -22,7 +35,10 @@ const series = fc
     .crossValue((d, i) => i)
     .mainValue(d => d)
     .defined(() => true)
-    .equals((previousData, data) => previousData.length > 0);
+    .equals((previousData, data) => previousData.length > 0)
+    .decorate(program => {
+        program.buffers().attribute('aDefined', mainValueAttribute);
+    });
 
 let pixels = null;
 let frame = 0;

--- a/packages/d3fc-webgl/README.md
+++ b/packages/d3fc-webgl/README.md
@@ -26,6 +26,7 @@ npm install @d3fc/d3fc-webgl
   * [Attribute Buffer Builders](#attribute-buffer-builders)
     * [Element Attribute](#element-attribute)
     * [Adjacent Element Attribute](#adjacent-element-attribute)
+    * [Streaming Element Attribute](#streaming-element-attribute)
     * [Vertex Attribute](#vertex-attribute)
     * [Base Attribute](#base-attribute)
     * [Constant Attribute](#constant-attribute)
@@ -495,6 +496,60 @@ If *type* is specified, sets the type property and returns this attribute builde
 The type property is used to specify the type of the typed array used for the buffer data, the default is `Float`. Valid types can be accessed from [webglTypes](#types).
 
 <a name="webglAdjacentElementAttribute_clear" href="#webglAdjacentElementAttribute_clear">#</a> *webglAdjacentElementAttribute*.**clear**()
+
+Used to indicate that the buffer should be rebuilt on the next render, by default the buffer will only be rebuilt if a property on the builder changes.
+
+##### Streaming Element Attribute
+
+<a name="webglStreamingElementAttribute" href="#webglStreamingElementAttribute">#</a> fc.**webglStreamingElementAttribute**()
+
+Used to generate a buffer containing values to be used on a per element basis. Values are updated in ranges using [enqueue](#webglStreamingElementAttribute_enqueue). In this context an element is an instance of a repeatedly drawn object, for example each individual candlestick on a candlestick chart is an element.
+
+<a name="webglStreamingElementAttribute_enqueue" href="#webglStreamingElementAttribute_enqueue">#</a> *webglStreamingElementAttribute*.**enqueue**(*data*, *offset*)
+
+The enqueue method specifies a range of *data* to be updated starting at the supplied *offset*. The length of the range is set by the length of *data*. 
+
+<a name="webglStreamingElementAttribute_normalized" href="#webglStreamingElementAttribute_normalized">#</a> *webglStreamingElementAttribute*.**normalized**(*boolean*)
+
+If *boolean* is specified, sets the normalized property and returns this attribute builder. If *boolean* is not specified, returns the current value of normalized.
+
+The normalized property specifies whether integer data values should be normalized when being cast to a float, the default value is false.
+
+More information on how values are normalized can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer).
+
+<a name="webglStreamingElementAttribute_location" href="#webglStreamingElementAttribute_location">#</a> *webglStreamingElementAttribute*.**location**(*index*)
+
+If *index* is specified, sets the location property and returns this attribute builder. If *index* is not specified, returns the current value of location.
+
+The location property is used to specify the index of the vertex attribute being modified. The appropriate value for an attribute can be found using [`WebGLRenderingContext.getAttribLocation()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getAttribLocation). This is normally specified on your behalf by [bufferBuilder](#buffer-builder).
+
+<a name="webglStreamingElementAttribute_count" href="#webglStreamingElementAttribute_count">#</a> *webglStreamingElementAttribute*.**count**(*count*)
+
+If *count* is specified, sets the count property and returns this attribute builder. If *count* is not specified, returns the current value of count.
+
+The count property sets the total number of values.
+
+<a name="webglStreamingElementAttribute_value" href="#webglStreamingElementAttribute_value">#</a> *webglStreamingElementAttribute*.**value**(*valueFunc*)
+
+If *valueFunc* is specified, sets the value property to the given function and returns this attribute builder. If *valueFunc* is not specified, returns the current value function.
+
+The value function is run for each entry in the data set, receiving the current data point and its index as arguments, *`valueFunc(data, index)`*.
+
+If the size property is set to `1`, then *valueFunc* must return a single value. If the size property is set to a value other than `1` then *valueFunc* must return an array of length equal to the size property.
+
+<a name="webglStreamingElementAttribute_size" href="#webglStreamingElementAttribute_size">#</a> *webglStreamingElementAttribute*.**size**(*size*)
+
+If *size* is specified, sets the size property and returns this attribute builder. If *size* is not specified, returns the current value of size.
+
+The size property is used to specify the number of components to the attribute. It must have the value `1` (default), `2`, `3`, or `4`, corresponding to the shader types `float`, `vec2`, `vec3`, and `vec4` respectively.
+
+<a name="webglStreamingElementAttribute_type" href="#webglStreamingElementAttribute_type">#</a> *webglStreamingElementAttribute*.**type**(*type*)
+
+If *type* is specified, sets the type property and returns this attribute builder. If *type* is not specified, returns the current type.
+
+The type property is used to specify the type of the typed array used for the buffer data. Valid types can be accessed from [webglTypes](#types).
+
+<a name="webglStreamingElementAttribute_clear" href="#webglStreamingElementAttribute_clear">#</a> *webglStreamingElementAttribute*.**clear**()
 
 Used to indicate that the buffer should be rebuilt on the next render, by default the buffer will only be rebuilt if a property on the builder changes.
 

--- a/packages/d3fc-webgl/README.md
+++ b/packages/d3fc-webgl/README.md
@@ -28,6 +28,7 @@ npm install @d3fc/d3fc-webgl
     * [Adjacent Element Attribute](#adjacent-element-attribute)
     * [Vertex Attribute](#vertex-attribute)
     * [Base Attribute](#base-attribute)
+    * [Constant Attribute](#constant-attribute)
   * [Uniform Builder](#uniform-builder)
   * [Buffer Builder](#buffer-builder)
   * [Element Indices](#element-indices)
@@ -598,6 +599,44 @@ The stride property is used to specify the offset in bytes between the start of 
 If *offset* is specified, sets the offset property and returns this attribute builder. If *offset* is not specified, returns the current offset.
 
 The offset property is used to specify the offset in bytes of the first value in the vertex attribute array. If set, the offset must be a multiple of the byte length of [type](#base-attribute).
+
+##### Constant Attribute
+
+<a name="webglConstantAttribute" href="#webglConstantAttribute">#</a> fc.**webglConstantAttribute**()
+
+Used to generate a buffer containing a single constant value to be used on for each vertex. 
+
+<a name="webglConstantAttribute_location" href="#webglConstantAttribute_location">#</a> *webglConstantAttribute*.**location**(*index*)
+
+If *index* is specified, sets the location property and returns this attribute builder. If *index* is not specified, returns the current value of location.
+
+The location property is used to specify the index of the vertex attribute being modified. The appropriate value for an attribute can be found using [`WebGLRenderingContext.getAttribLocation()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getAttribLocation). This is normally specified on your behalf by [bufferBuilder](#buffer-builder).
+
+<a name="webglConstantAttribute_size" href="#webglConstantAttribute_size">#</a> *webglConstantAttribute*.**size**(*size*)
+
+If *size* is specified, sets the size property and returns this attribute builder. If *size* is not specified, returns the current value of size.
+
+The size property is used to specify the number of components to the attribute. It must have the value `1` (default), `2`, `3`, or `4`, corresponding to the shader types `float`, `vec2`, `vec3`, and `vec4` respectively.
+
+<a name="webglConstantAttribute_type" href="#webglConstantAttribute_type">#</a> *webglConstantAttribute*.**type**(*type*)
+
+If *type* is specified, sets the type property and returns this attribute builder. If *type* is not specified, returns the current type.
+
+The type property is used to specify the type of the typed array used for the buffer data. Valid types can be accessed from [webglTypes](#types).
+
+<a name="webglConstantAttribute_normalized" href="#webglConstantAttribute_normalized">#</a> *webglConstantAttribute*.**normalized**(*boolean*)
+
+If *boolean* is specified, sets the normalized property and returns this attribute builder. If *boolean* is not specified, returns the current value of normalized.
+
+The normalized property specifies whether integer data values should be normalized when being cast to a float, the default value is false.
+
+More information on how values are normalized can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer).
+
+<a name="webglConstantAttribute_value" href="#webglConstantAttribute_value">#</a> *webglConstantAttribute*.**value**(*value*)
+
+If *value* is specified, sets the constant value and returns this attribute builder. If *value* is not specified, returns the current value.
+
+The value property is an array of length [size](#webglConstantAttribute_size).
 
 #### Uniform Builder
 

--- a/packages/d3fc-webgl/index.js
+++ b/packages/d3fc-webgl/index.js
@@ -11,6 +11,7 @@ export { default as webglBufferBuilder } from './src/buffer/bufferBuilder';
 export { default as webglBaseAttribute } from './src/buffer/baseAttribute';
 export { default as webglAdjacentElementAttribute } from './src/buffer/adjacentElementAttribute';
 export { default as webglElementAttribute } from './src/buffer/elementAttribute';
+export { default as webglStreamingElementAttribute } from './src/buffer/streamingElementAttribute';
 export { default as webglConstantAttribute } from './src/buffer/constantAttribute';
 export { default as webglVertexAttribute } from './src/buffer/vertexAttribute';
 export { default as webglUniform } from './src/buffer/uniform';

--- a/packages/d3fc-webgl/index.js
+++ b/packages/d3fc-webgl/index.js
@@ -11,6 +11,7 @@ export { default as webglBufferBuilder } from './src/buffer/bufferBuilder';
 export { default as webglBaseAttribute } from './src/buffer/baseAttribute';
 export { default as webglAdjacentElementAttribute } from './src/buffer/adjacentElementAttribute';
 export { default as webglElementAttribute } from './src/buffer/elementAttribute';
+export { default as webglConstantAttribute } from './src/buffer/constantAttribute';
 export { default as webglVertexAttribute } from './src/buffer/vertexAttribute';
 export { default as webglUniform } from './src/buffer/uniform';
 export { default as webglTypes } from './src/buffer/types';

--- a/packages/d3fc-webgl/src/buffer/streamingElementAttribute.js
+++ b/packages/d3fc-webgl/src/buffer/streamingElementAttribute.js
@@ -1,0 +1,56 @@
+import baseAttribute from './baseAttribute';
+import { rebind } from '@d3fc/d3fc-rebind';
+import attributeProjector from './attributeProjector';
+import { length } from './types';
+
+export default () => {
+    const base = baseAttribute().divisor(1);
+    const projector = attributeProjector();
+    const queue = [];
+    let count = 0;
+
+    const attribute = programBuilder => {
+        base.size(attribute.size()).type(attribute.type());
+
+        const requiresInitialisation = base.buffer() == null;
+
+        base(programBuilder);
+
+        const gl = programBuilder.context();
+        const bytes = attribute.size() * length(attribute.type());
+
+        if (requiresInitialisation) {
+            gl.bindBuffer(gl.ARRAY_BUFFER, base.buffer());
+            gl.bufferData(gl.ARRAY_BUFFER, count * bytes, gl.DYNAMIC_DRAW);
+        }
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, base.buffer());
+        while (queue.length > 0) {
+            const { data, offset } = queue.shift();
+            projector.data(data);
+            const projectedData = projector();
+            gl.bufferSubData(gl.ARRAY_BUFFER, offset * bytes, projectedData);
+        }
+    };
+
+    attribute.clear = () => {
+        base.buffer(null);
+    };
+
+    attribute.enqueue = (data, offset = 0) => {
+        queue.push({ data, offset });
+    };
+
+    attribute.count = (...args) => {
+        if (!args.length) {
+            return count;
+        }
+        count = args[0];
+        return attribute;
+    };
+
+    rebind(attribute, base, 'normalized', 'location');
+    rebind(attribute, projector, 'value', 'size', 'type');
+
+    return attribute;
+};


### PR DESCRIPTION
I'm not sure if this should be added to the project or just added as an example. There are a few tradeoffs to be aware of -

* Retaining the data outside of the GPU to allow recovering from context lost versus just streaming it straight in. Recovery could happen by re-requesting a snapshot from the server instead. This implementation does neither.
* Transferring the data to the GPU immediately rather than enqueuing for the next render. This is hard because of our internal API.
* As we're enqueuing for the next render and `attributeProjector` attempts to reuse buffers, the consumer can not reuse the `data` until they can be sure the data has been enqueued.

Additionally, in implementing this I noticed that we should profile the difference between using `buferData` on each render versus initialising with `bufferData` and then calling `bufferSubData` for loading data.