### PR TITLE
Make streaming chart work in Firefox

### DIFF
--- a/examples/streaming-chart/index.html
+++ b/examples/streaming-chart/index.html
@@ -8,7 +8,6 @@
     <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
     <style>
         body {
-            display: flex;
             margin: 0;
         }
 


### PR DESCRIPTION
Remove flex from the body.

Partially closes #1548.