### PR TITLE
feat: optimise seriesWebglRepeat performance

### DIFF
--- a/examples/series-webgl-repeat/index.js
+++ b/examples/series-webgl-repeat/index.js
@@ -7,18 +7,18 @@ d3.text('repeat-data.csv').then(text => {
 
     const yScale = d3.scaleLinear().domain([0, 60]);
 
-    const line = fc
-        .seriesWebglLine()
-        .crossValue((_, i) => i)
-        .mainValue(d => d);
-
     const color = d3.scaleOrdinal(d3.schemeCategory10);
 
     const series = fc
         .seriesWebglRepeat()
         .xScale(xScale)
         .yScale(yScale)
-        .series(line)
+        .series(() =>
+            fc
+                .seriesWebglLine()
+                .crossValue((_, i) => i)
+                .mainValue(d => d)
+        )
         .decorate((program, _, index) => {
             fc
                 .webglStrokeColor()

--- a/packages/d3fc-series/README.md
+++ b/packages/d3fc-series/README.md
@@ -1043,6 +1043,8 @@ The repeat series also exposes an *orient* property which determines the 'orient
 
 If *series* is specified, sets the series that this repeat series should render and returns this series. If *series* is not specified, returns the current series.
 
+For the WebGL implementation only, *series* can be specified as a function which when invoked returns a new series instance. This allows the repeat series to allocate a series instance per data series, preventing the unnecessary cache-evictions which can occur if only one series instance is used.
+
 <a name="seriesRepeat_orient" href="#seriesRepeat_orient">#</a> *seriesRepeat*.**orient**(*orientation*)
 
 If *orientation* is specified, sets the orientation and returns this series. If *orientation* is not specified, returns the current orientation. The orientation value should be either `vertical` (default) or `horizontal`.

--- a/packages/d3fc-series/index.js
+++ b/packages/d3fc-series/index.js
@@ -39,7 +39,7 @@ export { default as seriesCanvasGrouped } from './src/canvas/grouped';
 
 export { default as seriesSvgRepeat } from './src/svg/repeat';
 export { default as seriesCanvasRepeat } from './src/canvas/repeat';
-export { default as seriesWebglRepeat } from './src/canvas/repeat';
+export { default as seriesWebglRepeat } from './src/webgl/repeat';
 
 export { default as autoBandwidth } from './src/autoBandwidth';
 

--- a/packages/d3fc-series/src/webgl/repeat.js
+++ b/packages/d3fc-series/src/webgl/repeat.js
@@ -1,0 +1,52 @@
+import { rebindAll, exclude } from '@d3fc/d3fc-rebind';
+import multiSeries from '../canvas/multi';
+import line from './line';
+
+export default () => {
+
+    let orient = 'vertical';
+    let series = () => line();
+    const multi = multiSeries();
+    let seriesCache = [];
+
+    const repeat = (data) => {
+        if (orient === 'vertical') {
+            const previousSeriesCache = seriesCache;
+            seriesCache = data[0].map((d, i) => i < previousSeriesCache.length ? previousSeriesCache[i] : series());
+            multi.series(seriesCache)
+              .mapping((data, index) => data.map(d => d[index]));
+        } else {
+            const previousSeriesCache = seriesCache;
+            seriesCache = data.map((d, i) => i < previousSeriesCache.length ? previousSeriesCache[i] : series());
+            multi.series(seriesCache)
+              .mapping((data, index) => data[index]);
+        }
+        multi(data);
+    };
+
+    repeat.series = (...args) => {
+        if (!args.length) {
+            return series;
+        }
+        if (typeof args[0].xScale === 'function' && typeof args[0].yScale === 'function') {
+            series = () => args[0];
+        } else {
+            series = args[0];
+        }
+        seriesCache = [];
+        return repeat;
+    };
+
+    repeat.orient = (...args) => {
+        if (!args.length) {
+            return orient;
+        }
+        orient = args[0];
+        seriesCache = [];
+        return repeat;
+    };
+
+    rebindAll(repeat, multi, exclude('series', 'mapping'));
+
+    return repeat;
+};


### PR DESCRIPTION
The seriesWebglRepeat.series property can now be specified
as a function that returns a series instance rather than a series
instance. This allows the repeat series to allocate a series instance
per data series, preventing the unnecessary cache-evictions which can
occur if only one series instance is used.