### PR TITLE
fix: #1654: register custom elements used in charts

### DIFF
--- a/packages/d3fc-chart/src/cartesian.js
+++ b/packages/d3fc-chart/src/cartesian.js
@@ -3,6 +3,7 @@ import { scaleIdentity } from 'd3-scale';
 import { axisBottom, axisRight, axisLeft, axisTop } from '@d3fc/d3fc-axis';
 import { dataJoin, isTransition } from '@d3fc/d3fc-data-join';
 import { rebindAll, exclude, prefix } from '@d3fc/d3fc-rebind';
+import '@d3fc/d3fc-element';
 import store from './store';
 import './css';
 


### PR DESCRIPTION
Import d3fc-element so that custom elements are registered. Simples.

Fixes #1654 