### PR TITLE
Update d3fc chart types

### DIFF
--- a/packages/d3fc-chart/index.d.ts
+++ b/packages/d3fc-chart/index.d.ts
@@ -1,3 +1,1 @@
-export { default as chartSvgCartesian } from './src/svg/cartesian';
-export { default as chartCanvasCartesian } from './src/canvas/cartesian';
 export { default as chartCartesian } from './src/cartesian';

--- a/packages/d3fc-chart/src/cartesian.d.ts
+++ b/packages/d3fc-chart/src/cartesian.d.ts
@@ -246,11 +246,11 @@ export type CartesianChart<XScale, YScale> = {
     yOrient(orient: TypeOrFunctor<YOrient>): CartesianChart<XScale, YScale>;
 }
     & AnyMethods<PrefixProperties<OmitPrefixes<XScale>, 'x'>>
-    & AnyMethods<PrefixProperties<OmitPrefixes<XScale>, 'y'>>
+    & AnyMethods<PrefixProperties<OmitPrefixes<YScale>, 'y'>>
     & AnyMethods<PrefixProperties<AxisD3fc<any>, 'x'>>
     & AnyMethods<PrefixProperties<AxisD3fc<any>, 'y'>>;
 
-export type Fallback<T> = undefined extends T ? ScaleIdentity : T;
+export type Fallback<T> = T extends undefined ? ScaleIdentity : T;
 
 export interface Scale {
     range: any;

--- a/packages/d3fc-chart/test-d/cartesian.test-d.ts
+++ b/packages/d3fc-chart/test-d/cartesian.test-d.ts
@@ -66,3 +66,11 @@ expectType<WebglPlotAreaComponent | null>(chart.webglPlotArea());
 expectType<CanvasPlotAreaComponent | null>(chart.canvasPlotArea());
 expectType<SvgPlotAreaComponent | null>(chart.svgPlotArea());
 expectType<boolean>(chart.useDevicePixelRatio());
+
+// Correctly rebinds methods from non ScaleIdentity scales
+const chartScaleBand = chartCartesian(d3.scaleBand(), d3.scaleLinear());
+expectType<any>(chartScaleBand.xPadding());
+expectType<any>(chartScaleBand.xPadding(5));
+
+expectType<any>(chartScaleBand.yNice());
+expectType<any>(chartScaleBand.yNice(5));


### PR DESCRIPTION
fix: type rebinding from chart Scale generics
fix: remove deprecated export from d3fc-chart