### PR TITLE
Prevent registering components multiple times

### DIFF
--- a/packages/d3fc-element/index.js
+++ b/packages/d3fc-element/index.js
@@ -13,9 +13,23 @@ if (
     );
 }
 
-const registerElement = (name, element) =>
-    customElements.get(name) || customElements.define(name, element);
+const alreadyRegistered = [];
+const registerElement = (name, element) => {
+    if (customElements.get(name)) {
+        alreadyRegistered.push(name);
+    } else {
+        customElements.define(name, element);
+    }
+};
 
 registerElement('d3fc-canvas', Canvas);
 registerElement('d3fc-group', Group);
 registerElement('d3fc-svg', Svg);
+
+if (alreadyRegistered.length > 0) {
+    console.warn(
+        `The d3fc components "${alreadyRegistered.join(
+            ', '
+        )}" is/are already registered on window. Be aware that this can create compatibility issues if different versions are used.`
+    );
+}

--- a/packages/d3fc-element/index.js
+++ b/packages/d3fc-element/index.js
@@ -4,10 +4,18 @@ import Group from './src/group';
 import Svg from './src/svg';
 import './src/css';
 
-if (typeof customElements !== 'object' || typeof customElements.define !== 'function') {
-    throw new Error('d3fc-element depends on Custom Elements (v1). Make sure that you load a polyfill in older browsers. See README.');
+if (
+    typeof customElements !== 'object' ||
+    typeof customElements.define !== 'function'
+) {
+    throw new Error(
+        'd3fc-element depends on Custom Elements (v1). Make sure that you load a polyfill in older browsers. See README.'
+    );
 }
 
-customElements.define('d3fc-canvas', Canvas);
-customElements.define('d3fc-group', Group);
-customElements.define('d3fc-svg', Svg);
+const registerElement = (name, element) =>
+    customElements.get(name) || customElements.define(name, element);
+
+registerElement('d3fc-canvas', Canvas);
+registerElement('d3fc-group', Group);
+registerElement('d3fc-svg', Svg);


### PR DESCRIPTION
When using webcomponents that are using d3-fc the different
webcomponents don't know if another component has
already registered the d3fc components,
causing an error.