### PR TITLE
fix: pin node to latest working version

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 21.7.3
 
       - name: "Install dependencies"
         run: npm ci
@@ -45,7 +45,7 @@ jobs:
       - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 21.7.3
 
       - name: "Install dependencies"
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         - name: "Setup Node"
           uses: actions/setup-node@v3
           with:
-            node-version: latest
+            node-version: 21.7.3
             registry-url: https://registry.npmjs.org/
         
         - name: "Install dependencies"


### PR DESCRIPTION
A recent node version upgrade (v22) breaks **npm ci** locally and in Github actions workflows:
https://github.com/d3fc/d3fc/actions/runs/8911443255/job/24472763515?pr=1808

This PR pins node to the most recent working version to fix the CI workllows and allow other work to be done while we figure out how to upgrade successfully to the latest version.