### PR TITLE
Ignore dependabot commits

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
+  }
+  

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-    extends: ['@commitlint/config-conventional'],
-    ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
-  }
-  
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => /Signed-off-by: dependabot\[bot]\s+<support@github\.com>$/m.test(message)],
+}

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": ["@commitlint/config-conventional"]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 examples/*/__tests__/__image_snapshots__
 examples/*/__tests__/__snapshots__
 examples/*/__tests__/__traces__
-.*
+


### PR DESCRIPTION
Dependabot is consistently breaking the `Code Standards` job. This should get commitlint to ignore all Dependabot commits.

![image](https://github.com/d3fc/d3fc/assets/60654572/3ad3a46d-aeb7-40a7-82f7-e7d38089cbc6)

![image](https://github.com/d3fc/d3fc/assets/60654572/06e6328f-486c-4d2d-8712-22ca49315424)
