### PR TITLE
fix: add deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
           uses: actions/checkout@v3
           with:
             fetch-depth: 0
+            ssh-key: ${{secrets.DEPLOY_KEY}}
 
         - name: "Setup Node"
           uses: actions/setup-node@v3


### PR DESCRIPTION
Releases are failing due to branch protections - I have added deploy keys to the repo. This PR should fix the issue - will have to test on merge.

![image](https://github.com/d3fc/d3fc/assets/60654572/b281a2b6-428e-4b72-93f6-89e32049ac42)
