### PR TITLE
WIP fix: specify publishConfig for main package

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
     "tsd": "^0.28.1",
     "typescript": "^4.9.5"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
Noticed there was an inconsistency with how our npm settings were set up, where the main package doesn't specify the 'access' field in its "publishConfig": {}, which all the other packages do.