### PR TITLE
feat: add create-release to lerna publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,94 +1,94 @@
 {
-  "name": "@d3fc/d3fc-monorepo",
-  "private": true,
-  "description": "A collection of components that make it easy to build interactive charts with D3",
-  "workspaces": [
-    "./packages/*"
-  ],
-  "scripts": {
-    "publish": "lerna publish --conventional-commits --message \"chore: publish\" --yes",
-    "bundle": "lerna run bundle --stream --concurrency 1",
-    "bundle-min": "lerna run bundle --stream --concurrency 1 -- --configEnv=prod",
-    "test": "jest --config scripts/jest/jest.config.js && npm run test:types",
-    "eslint": "eslint . --ext .js --ext .ts",
-    "markdownlint": "markdownlint **/*.md --ignore **/node_modules/**",
-    "lint": "npm run eslint && npm run markdownlint",
-    "start": "lerna run bundle && npm start --prefix ./packages/d3fc",
-    "commitlint": "commitlint --from HEAD~1 --to HEAD --verbose",
-    "examples": "cd examples && npx jest --runInBand",
-    "test:types": "lerna run test:types"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "tabWidth": 4
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/d3fc/d3fc.git",
-    "_homepage": "https://github.com/d3fc/d3fc"
-  },
-  "keywords": [
-    "d3",
-    "financial",
-    "components",
-    "charts"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/d3fc/d3fc/issues"
-  },
-  "homepage": "https://d3fc.io",
-  "devDependencies": {
-    "@babel/core": "^7.22.5",
-    "@babel/preset-env": "^7.22.5",
-    "@babel/register": "^7.22.5",
-    "@commitlint/cli": "^19.3.0",
-    "@commitlint/config-conventional": "^19.2.2",
-    "@commitlint/travis-cli": "^19.3.0",
-    "@types/d3": "^6.7.5",
-    "@types/jest": "^26.0.24",
-    "@typescript-eslint/eslint-plugin": "^4.33.0",
-    "@typescript-eslint/parser": "^4.33.0",
-    "babelrc-rollup": "^3.0.0",
-    "canvas": "^2.11.2",
-    "chalk": "^2.4.2",
-    "commitizen": "^4.3.0",
-    "cz-conventional-changelog": "^3.0.2",
-    "d3": "^6.7.0",
-    "eslint": "^7.32.0",
-    "eslint-config-prettier": "^6.15.0",
-    "eslint-config-semistandard": "^15.0.1",
-    "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.4.1",
-    "eslint-plugin-promise": "^4.3.1",
-    "eslint-plugin-standard": "^4.1.0",
-    "glsl-transpiler": "^1.8.6",
-    "jest": "^24.9.0",
-    "jest-image-snapshot": "^6.4.0",
-    "jest-puppeteer": "^4.4.0",
-    "js-combinatorics": "^0.5.5",
-    "jsdom": "^9.12.0",
-    "lerna": "^8.1.2",
-    "markdownlint": "^0.16.0",
-    "markdownlint-cli": "^0.17.0",
-    "mockdate": "^2.0.5",
-    "prettier": "^1.19.1",
-    "puppeteer": "^1.20.0",
-    "rollup": "^2.79.1",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-babel-minify": "^10.0.0",
-    "rollup-plugin-livereload": "^2.0.5",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-serve": "^1.1.0",
-    "seedrandom": "^3.0.5",
-    "tsd": "^0.28.1",
-    "typescript": "^4.9.5"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
+    "name": "@d3fc/d3fc-monorepo",
+    "private": true,
+    "description": "A collection of components that make it easy to build interactive charts with D3",
+    "workspaces": [
+        "./packages/*"
+    ],
+    "scripts": {
+        "publish": "lerna publish --conventional-commits --create-release github --message \"chore: publish\" --yes",
+        "bundle": "lerna run bundle --stream --concurrency 1",
+        "bundle-min": "lerna run bundle --stream --concurrency 1 -- --configEnv=prod",
+        "test": "jest --config scripts/jest/jest.config.js && npm run test:types",
+        "eslint": "eslint . --ext .js --ext .ts",
+        "markdownlint": "markdownlint **/*.md --ignore **/node_modules/**",
+        "lint": "npm run eslint && npm run markdownlint",
+        "start": "lerna run bundle && npm start --prefix ./packages/d3fc",
+        "commitlint": "commitlint --from HEAD~1 --to HEAD --verbose",
+        "examples": "cd examples && npx jest --runInBand",
+        "test:types": "lerna run test:types"
+    },
+    "prettier": {
+        "singleQuote": true,
+        "tabWidth": 4
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/d3fc/d3fc.git",
+        "_homepage": "https://github.com/d3fc/d3fc"
+    },
+    "keywords": [
+        "d3",
+        "financial",
+        "components",
+        "charts"
+    ],
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/d3fc/d3fc/issues"
+    },
+    "homepage": "https://d3fc.io",
+    "devDependencies": {
+        "@babel/core": "^7.22.5",
+        "@babel/preset-env": "^7.22.5",
+        "@babel/register": "^7.22.5",
+        "@commitlint/cli": "^19.3.0",
+        "@commitlint/config-conventional": "^19.2.2",
+        "@commitlint/travis-cli": "^19.3.0",
+        "@types/d3": "^6.7.5",
+        "@types/jest": "^26.0.24",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "babelrc-rollup": "^3.0.0",
+        "canvas": "^2.11.2",
+        "chalk": "^2.4.2",
+        "commitizen": "^4.3.0",
+        "cz-conventional-changelog": "^3.0.2",
+        "d3": "^6.7.0",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-config-semistandard": "^15.0.1",
+        "eslint-config-standard": "^14.1.1",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^3.4.1",
+        "eslint-plugin-promise": "^4.3.1",
+        "eslint-plugin-standard": "^4.1.0",
+        "glsl-transpiler": "^1.8.6",
+        "jest": "^24.9.0",
+        "jest-image-snapshot": "^6.4.0",
+        "jest-puppeteer": "^4.4.0",
+        "js-combinatorics": "^0.5.5",
+        "jsdom": "^9.12.0",
+        "lerna": "^8.1.2",
+        "markdownlint": "^0.16.0",
+        "markdownlint-cli": "^0.17.0",
+        "mockdate": "^2.0.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rollup": "^2.79.1",
+        "rollup-plugin-babel": "^4.4.0",
+        "rollup-plugin-babel-minify": "^10.0.0",
+        "rollup-plugin-livereload": "^2.0.5",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-serve": "^1.1.0",
+        "seedrandom": "^3.0.5",
+        "tsd": "^0.28.1",
+        "typescript": "^4.9.5"
+    },
+    "config": {
+        "commitizen": {
+            "path": "./node_modules/cz-conventional-changelog"
+        }
     }
-  }
 }


### PR DESCRIPTION
Added `create-release` to the Lerna publish script to allow generation of Github release notes