### PR TITLE
fix: add GH_TOKEN to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,4 @@ jobs:
           run: npm run publish
           env:
             NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+            GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Adds GH_TOKEN env var to release pipeline to allow Lerna to create GitHub releases