### PR TITLE
fix: add build to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
         - name: "Install dependencies"
           run: npm ci
 
+        - name: "Build"
+          run: |
+            npm run bundle
+            npm run bundle-min
+
         - name: "Publish"
           run: npm run publish
           env:


### PR DESCRIPTION
Because the `release.yml` pipeline uses a reusuable `development.yml` workflow for the build and test, which runs as a separate job, the build files are lost, meaning they aren't being uploaded to npm. 

This PR adds a `build` step into the `release.yml` - we could choose to upload and download the build files between the jobs (see [stack overflow](https://stackoverflow.com/questions/57498605/github-actions-share-workspace-artifacts-between-jobs)), but adding the build step in into the release pipeline is easier to do due to the structure of the repo.  