### PR TITLE
fix: change .changeset access to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
Publish step is failing with 'error npm ERR! Can't restrict access to unscoped packages.' - this should fix that