### PR TITLE
Fix doji candlesticks in webgl (main repo version)

### DIFF
--- a/.changeset/short-bananas-trade.md
+++ b/.changeset/short-bananas-trade.md
@@ -1,0 +1,5 @@
+---
+'@d3fc/d3fc-webgl': patch
+---
+
+Fix webgl candlestick body height

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -185,7 +185,9 @@ export const candlestick = {
          (isNotPositiveY * isExtremeY * aHighValue);
 
         float lineWidthXDirection = (isNotExtremeY * aCorner.x) + (isExtremeY * aCorner.z);
-        float lineWidthYDirection = isNotExtremeY * sign(aCloseValue - aOpenValue) * aCorner.y;
+
+        float bodyThickness = (aOpenValue == aCloseValue ? 1.0 : sign(aCloseValue - aOpenValue));
+        float lineWidthYDirection = (isNotExtremeY * bodyThickness * aCorner.y);
 
         float bandwidthModifier = aBandwidth * aCorner.x / 2.0;
 


### PR DESCRIPTION
Copy of the changes in https://github.com/d3fc/d3fc/pull/1804 on new branch, as changesets don't quite work as intended from the master branch of a fork. The branch attached to the original PR can't be swapped out, so commits have been cherry picked to this one.

Credit to [tradingcage ](https://github.com/tradingcage)for the fix. Description from the original PR:

> Currently, when you use a WebGL series to display a pure doji candlestick (where the close and open price are equal), it sets the candlestick body height to 0, omitting it entirely. This looks weird because it displays the candlesticks as wicks only. This bug doesn't duplicate for canvas candlestick series, only webgl. This PR fixes it by setting the height of the body to the minimum value when the open and close are equal.
> 
> Tested by editing examples/simple-chart/index.js to look like this:
> 
> ```
> const data = fc.randomFinancial()(50).map(bar => ({ ...bar, close: bar.open }));
> 
> const yExtent = fc.extentLinear().accessors([d => d.high, d => d.low]);
> 
> const xExtent = fc.extentDate().accessors([d => d.date]);
> 
> const gridlines = fc.annotationSvgGridline();
> const candlestick = fc.seriesWebglCandlestick();
> const multi = fc.seriesSvgMulti().series([gridlines]);
> 
> const chart = fc
>     .chartCartesian(d3.scaleTime(), d3.scaleLinear())
>     .svgPlotArea(multi)
>     .webglPlotArea(candlestick)
> 
> chart.xDomain(xExtent(data));
> chart.yDomain(yExtent(data));
> 
> d3.select('#chart')
>     .datum(data)
>     .call(chart);
> ```
> 
> Before:
> 
> <img alt="Screen Shot 2024-01-15 at 3 06 03 PM" width="1771" src="https://private-user-images.githubusercontent.com/143196169/296870131-fc25f7e3-cf6c-4e84-b4a7-b194c12b38ff.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjA2MTYyMTAsIm5iZiI6MTcyMDYxNTkxMCwicGF0aCI6Ii8xNDMxOTYxNjkvMjk2ODcwMTMxLWZjMjVmN2UzLWNmNmMtNGU4NC1iNGE3LWIxOTRjMTJiMzhmZi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzEwJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDcxMFQxMjUxNTBaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02ZDYyODdkMDJiMzc3ZGVkNjk3Y2E5ZGI0NzJhNzI5MWE0OTNkMDE0ZTJhZjk4Mzc5MWFlODA2YmYxODZmN2VmJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.E8JozUS1dVfDIM4CrUaDtYSvqZW8DXEvjHQUbGOV208">
> After:
> 
> <img alt="Screen Shot 2024-01-15 at 3 05 42 PM" width="1772" src="https://private-user-images.githubusercontent.com/143196169/296870202-b6599e15-4b93-4fa6-88d1-cd89f37cafb6.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjA2MTYyMTAsIm5iZiI6MTcyMDYxNTkxMCwicGF0aCI6Ii8xNDMxOTYxNjkvMjk2ODcwMjAyLWI2NTk5ZTE1LTRiOTMtNGZhNi04OGQxLWNkODlmMzdjYWZiNi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzEwJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDcxMFQxMjUxNTBaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02OTY1ZGY5NGU4OGNlZDZjYTczOGM4ZDdhODg1NDY2MDM5ZDEzOTliNWEzNWExMzZjYTUwM2ExM2Y3MTViNDk4JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.ueRrxPyGH_aoxarQr6ioCP91RZdUjiyp1hgE7Tv-TCE">