### PR TITLE
chore: add changeset for fixed deployment

### DIFF
--- a/.changeset/a-new-changeset.md
+++ b/.changeset/a-new-changeset.md
@@ -1,0 +1,5 @@
+---
+'@d3fc/d3fc-webgl': patch
+---
+
+Fix webgl candlestick body height


### PR DESCRIPTION
Deployment for #1870 did not work due to secondary rate limits being hit, should be fixed in #1872. This PR is an attempt to deploy the changes from #1870. 