### PR TITLE
chore: update changesets-action fork version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Publish to npm"
         id: changesets
-        uses: d3fc/changesets-action@v1.0.0
+        uses: d3fc/changesets-action@v1.4.8
         with:
           publish: npm run publish
         env:


### PR DESCRIPTION
Previous version wasn't built properly and was missing the /dist directory. Performed a release on the [forked changesets-action repo](https://github.com/d3fc/changesets-action/tree/v1.4.8/) to create the build files.