### PR TITLE
fix: use experimental feature to get changeset to bump internal dependencies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,14 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
-  "commit": false,
-  "fixed": [],
-  "linked": [],
-  "access": "public",
-  "baseBranch": "master",
-  "updateInternalDependencies": "patch",
-  "ignore": []
+    "$schema": "https://unpkg.com/@changesets/config@3.0.1/schema.json",
+    "changelog": "@changesets/cli/changelog",
+    "commit": false,
+    "fixed": [],
+    "linked": [],
+    "access": "public",
+    "baseBranch": "master",
+    "updateInternalDependencies": "patch",
+    "ignore": [],
+    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+        "updateInternalDependents": "always"
+    }
 }


### PR DESCRIPTION
Since moving to Changesets from Lerna, we have realised that the internal dependencies for D3FC have not been updated, meaning a new version of D3FC has not been published. 

Using this experimental feature allows changesets to update the internal dependencies - this [branch](https://github.com/d3fc/d3fc/compare/master...manually-bump-d3fc)  was used as a test, to see what would happen using the feature and then running `changesets version`. 

Although this is an experimental feature, we feel that as the feature has been in the Changesets repo for two years, and we are using a fork, it should be stable and suitable for our use.