### PR TITLE
fix: exclude gh actions bot from commitlint

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [(message) => /Signed-off-by: dependabot\[bot]\s+<support@github\.com>$/m.test(message)],
+  ignores: [
+    (message) => /Signed-off-by: dependabot\[bot]\s+<support@github\.com>$/m.test(message),
+    (message) => /github-actions\[bot\]/.test(message)
+  ],
 }


### PR DESCRIPTION
Should stop the Version Packaging commits from the changeset gh-action from failing the pipelines.