### PR TITLE
Update changesets action fork version

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   ignores: [
     (message) => /Signed-off-by: dependabot\[bot]\s+<support@github\.com>$/m.test(message),
-    (message) => /github-actions\[bot\]/.test(message)
   ],
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Publish to npm"
         id: changesets
-        uses: d3fc/changesets-action@v1.4.8
+        uses: d3fc/changesets-action@v1.4.9
         with:
           publish: npm run publish
         env:


### PR DESCRIPTION
I updated the forked version of this github action so that the default commit aligns with our linter.
https://github.com/d3fc/changesets-action/pull/4/files

This bumps us up to that version to save adding an exception for the 'Version Package' commit.