### PR TITLE
feat: add es module version to bundles

### DIFF
--- a/.changeset/funny-drinks-destroy.md
+++ b/.changeset/funny-drinks-destroy.md
@@ -1,0 +1,25 @@
+---
+'@d3fc/d3fc-discontinuous-scale': minor
+'@d3fc/d3fc-technical-indicator': minor
+'@d3fc/d3fc-financial-feed': minor
+'@d3fc/d3fc-label-layout': minor
+'@d3fc/d3fc-random-data': minor
+'@d3fc/d3fc-annotation': minor
+'@d3fc/d3fc-data-join': minor
+'@d3fc/d3fc-element': minor
+'@d3fc/d3fc-pointer': minor
+'@d3fc/d3fc-extent': minor
+'@d3fc/d3fc-rebind': minor
+'@d3fc/d3fc-sample': minor
+'@d3fc/d3fc-series': minor
+'@d3fc/d3fc-brush': minor
+'@d3fc/d3fc-chart': minor
+'@d3fc/d3fc-group': minor
+'@d3fc/d3fc-shape': minor
+'@d3fc/d3fc-webgl': minor
+'@d3fc/d3fc-axis': minor
+'@d3fc/d3fc-zoom': minor
+'d3fc': minor
+---
+
+add es module version

--- a/packages/d3fc-annotation/package.json
+++ b/packages/d3fc-annotation/package.json
@@ -10,7 +10,12 @@
         "crosshair"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-annotation.js",
+    "exports": {
+        "import": "./build/d3fc-annotation.mjs",
+        "require": "./build/d3fc-annotation.js"
+    },
     "module": "index",
     "repository": {
         "type": "git",

--- a/packages/d3fc-axis/package.json
+++ b/packages/d3fc-axis/package.json
@@ -9,8 +9,12 @@
         "axis"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-axis.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-axis.mjs",
+        "require": "./build/d3fc-axis.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-brush/package.json
+++ b/packages/d3fc-brush/package.json
@@ -9,8 +9,12 @@
     "brush"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-brush.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-brush.mjs",
+      "require": "./build/d3fc-brush.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-chart/package.json
+++ b/packages/d3fc-chart/package.json
@@ -10,8 +10,12 @@
         "cartesian"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-chart.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-chart.mjs",
+        "require": "./build/d3fc-chart.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-data-join/package.json
+++ b/packages/d3fc-data-join/package.json
@@ -9,8 +9,12 @@
     "datajoin"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-data-join.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-data-join.mjs",
+      "require": "./build/d3fc-data-join.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-discontinuous-scale/package.json
+++ b/packages/d3fc-discontinuous-scale/package.json
@@ -9,8 +9,12 @@
         "scale"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-discontinuous-scale.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-discontinuous-scale.mjs",
+        "require": "./build/d3fc-discontinuous-scale.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-element/package.json
+++ b/packages/d3fc-element/package.json
@@ -9,8 +9,12 @@
     "element"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-element.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-element.mjs",
+      "require": "./build/d3fc-element.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-extent/package.json
+++ b/packages/d3fc-extent/package.json
@@ -12,8 +12,12 @@
     "date"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-extent.js",
-  "module": "index",
+  "exports": {
+    "import": "./build/d3fc-extent.mjs",
+    "require": "./build/d3fc-extent.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-financial-feed/package.json
+++ b/packages/d3fc-financial-feed/package.json
@@ -12,8 +12,12 @@
     "gdax"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-financial-feed.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-financial-feed.mjs",
+      "require": "./build/d3fc-financial-feed.js"
+  },
   "typings": "@d3fc/d3fc-financial-feed.d.ts",
   "repository": {
     "type": "git",

--- a/packages/d3fc-group/package.json
+++ b/packages/d3fc-group/package.json
@@ -11,8 +11,12 @@
     "d3fc"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-group.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-group.mjs",
+      "require": "./build/d3fc-group.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-label-layout/package.json
+++ b/packages/d3fc-label-layout/package.json
@@ -10,8 +10,12 @@
         "layout"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-label-layout.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-label-layout.mjs",
+        "require": "./build/d3fc-label-layout.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-pointer/package.json
+++ b/packages/d3fc-pointer/package.json
@@ -2,8 +2,12 @@
     "name": "@d3fc/d3fc-pointer",
     "version": "3.0.3",
     "description": "Component which emits the current mouse or touch position over a selection",
+    "type": "module",
     "main": "build/d3fc-pointer.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-pointer.mjs",
+        "require": "./build/d3fc-pointer.js"
+    },
     "scripts": {
         "bundle": "npx rollup -c ../../scripts/rollup.config.js",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-pointer"

--- a/packages/d3fc-random-data/package.json
+++ b/packages/d3fc-random-data/package.json
@@ -17,8 +17,12 @@
         "stream"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-random-data.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-random-data.mjs",
+        "require": "./build/d3fc-random-data.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-rebind/package.json
+++ b/packages/d3fc-rebind/package.json
@@ -11,8 +11,12 @@
     "all"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-rebind.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-rebind.mjs",
+      "require": "./build/d3fc-rebind.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-sample/package.json
+++ b/packages/d3fc-sample/package.json
@@ -10,8 +10,12 @@
         "sampler"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-sample.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-sample.mjs",
+        "require": "./build/d3fc-sample.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-series/package.json
+++ b/packages/d3fc-series/package.json
@@ -9,8 +9,12 @@
         "series"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-series.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-series.mjs",
+        "require": "./build/d3fc-series.js"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-shape/package.json
+++ b/packages/d3fc-shape/package.json
@@ -13,8 +13,12 @@
     "context2d"
   ],
   "homepage": "https://github.com/d3fc/d3fc",
+  "type": "module",
   "main": "build/d3fc-shape.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-shape.mjs",
+      "require": "./build/d3fc-shape.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"

--- a/packages/d3fc-technical-indicator/package.json
+++ b/packages/d3fc-technical-indicator/package.json
@@ -25,8 +25,12 @@
         "stochastic oscillator"
     ],
     "homepage": "https://github.com/d3fc/d3fc",
+    "type": "module",
     "main": "build/d3fc-technical-indicator.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-technical-indicator.mjs",
+        "require": "./build/d3fc-technical-indicator.js"
+    },
     "typings": "@d3fc/d3fc-technical-indicator.d.ts",
     "repository": {
         "type": "git",

--- a/packages/d3fc-webgl/package.json
+++ b/packages/d3fc-webgl/package.json
@@ -12,8 +12,12 @@
     "type": "git",
     "url": "https://github.com/d3fc/d3fc"
   },
+  "type": "module",
   "main": "build/d3fc-webgl.js",
-  "module": "index",
+  "exports": {
+      "import": "./build/d3fc-webgl.mjs",
+      "require": "./build/d3fc-webgl.js"
+  },
   "scripts": {
     "bundle": "npx rollup -c ../../scripts/rollup.config.js",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-webgl"

--- a/packages/d3fc-zoom/package.json
+++ b/packages/d3fc-zoom/package.json
@@ -2,8 +2,12 @@
     "name": "@d3fc/d3fc-zoom",
     "version": "1.2.0",
     "description": "A zoom component which operates in domain values",
+    "type": "module",
     "main": "build/d3fc-zoom.js",
-    "module": "index",
+    "exports": {
+        "import": "./build/d3fc-zoom.mjs",
+        "require": "./build/d3fc-zoom.js"
+    },
     "scripts": {
         "bundle": "npx rollup -c ../../scripts/rollup.config.js",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-zoom"

--- a/packages/d3fc/package.json
+++ b/packages/d3fc/package.json
@@ -2,7 +2,12 @@
     "name": "d3fc",
     "version": "15.2.13",
     "description": "A collection of components that make it easy to build interactive charts with D3",
+    "type": "module",
     "main": "build/d3fc.js",
+    "exports": {
+        "import": "./build/d3fc.mjs",
+        "require": "./build/d3fc.js"
+    },
     "scripts": {
         "start": "npx rollup -c --environment BUILD:dev --watch",
         "bundle": "npx rollup -c"

--- a/packages/d3fc/rollup.config.js
+++ b/packages/d3fc/rollup.config.js
@@ -32,6 +32,7 @@ export default commandLineArgs => {
 
     process.env.env = commandLineArgs.configEnv || 'dev';
     const shouldMinify = process.env.env === 'prod';
+    const formats = process.env.BUILD !== undefined ? ['umd'] : ['umd', 'es'];
 
     const _plugins = [
         babel({ cwd: '../..' }),
@@ -56,14 +57,14 @@ export default commandLineArgs => {
         })
     ]);
 
-    return {
+    return formats.map((format) => ({
         input: 'index.js',
         plugins: devMode ? devPlugins() : plugins(),
         external: (key) => key.indexOf('d3-') === 0,
         output: {
-            file: `build/${d3fcPkg.name}${shouldMinify ? '.min' : ''}.js`,
-            format: 'umd',
-            name: 'fc',
+            file: `build/${d3fcPkg.name}${shouldMinify ? '.min' : ''}.${format === 'es' ? 'mjs' : 'js'}`,
+            format,
+            ...(format === 'umd' && { name: 'fc' }),
             globals: (key) => {
                 if (key.indexOf('d3-') === 0) {
                     return 'd3';
@@ -79,5 +80,5 @@ export default commandLineArgs => {
 
             rollupWarn(warning);
         }
-    };
+    }));
 };

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -13,6 +13,8 @@ var globals = function(key) {
     }
 };
 
+const formats = ['umd', 'es'];
+
 export default commandLineArgs => {
     process.env.env = commandLineArgs.configEnv || 'dev';
     const shouldMinify = process.env.env === 'prod';
@@ -31,16 +33,18 @@ export default commandLineArgs => {
         throw Error('Expected package.json to contain `name` field');
     }
     name = name.replace('@d3fc/', '');
-    return {
+    return formats.map(format => ({
         input: 'index.js',
         plugins: plugins,
         external: external,
         output: {
-            file: `build/${name}${shouldMinify ? '.min' : ''}.js`,
-            format: 'umd',
+            file: `build/${name}${shouldMinify ? '.min' : ''}.${
+                format === 'es' ? 'mjs' : 'js'
+            }`,
+            format,
             globals: globals,
             extend: true,
-            name: 'fc'
+            ...(format === 'umd' && { name: 'fc' })
         }
-    };
+    }));
 };


### PR DESCRIPTION
Adds additional `rollup` bundle for ES modules, so it can be easily exposed in `exports` in `package.json`. Development build stays the same and uses `umd`.

Should address #1715 and  #1774.