### PR TITLE
fix(webgl): add canFill and canStroke to diamnd point

### DIFF
--- a/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
@@ -123,6 +123,7 @@ export const diamond = {
         float b = 1.0;
     `,
     body: `
+        float canFill = 1.0;
         if (vDefined < 0.5) {
             discard;
         }
@@ -137,6 +138,7 @@ export const diamond = {
 
         float distance = length(vec2(x, y)) / length(vec2(X, Y));
 
+        float canStroke = smoothstep(vSize - 2.0, vSize, distance * vSize);
         if (distance > 1.0) {
             discard;
         }


### PR DESCRIPTION
## Symptoms

When using `webglFillColor()` or `webglStrokeColor()` via `.decorate()` on a WebGL point series with `d3.symbolDiamond`, the diamond points fail to render. The canvas is blank and the browser console shows WebGL errors: `useProgram: program not valid` and `no valid shader program in use`.

## Cause

The diamond fragment shader in `fragmentShaderSnippets.js` was missing `canFill` and `canStroke` variable declarations. When `webglFillColor()` or `webglStrokeColor()` is applied, it appends shader code that references these variables. Since diamond didn't define them, the GLSL shader failed to compile. Every other point type (circle, square, star, triangle, cross, wye) already defined both variables.

## Solution

Added `float canFill = 1.0;` and `float canStroke = smoothstep(vSize - 2.0, vSize, distance * vSize);` to the diamond fragment shader body, matching the pattern used by all other point types.

## Before (broken — blank canvas, WebGL shader errors in console)

![before](https://github.com/user-attachments/assets/990f2816-0a46-4c69-8fa1-a60c33693301)

## After (fixed — diamond points render correctly)

![after](https://github.com/user-attachments/assets/1f84c409-4c3d-4253-a987-ff498eb926b7)
