### PR TITLE
fix(axis): use ternary for visibility attr to return null instead of false

### DIFF
--- a/.changeset/fix-axis-visibility.md
+++ b/.changeset/fix-axis-visibility.md
@@ -1,0 +1,5 @@
+---
+'@d3fc/d3fc-axis': patch
+---
+
+Fix axis setting invalid SVG `visibility="false"` on visible tick elements. The `&&` operator returned `false` instead of `null`, causing D3 to set an invalid attribute value rather than removing the attribute.

--- a/packages/d3fc-axis/src/axisBase.js
+++ b/packages/d3fc-axis/src/axisBase.js
@@ -121,13 +121,13 @@ export const axisBase = (orient, scale, custom = {}) => {
 
             // update
             g.select('path')
-                .attr('visibility', (d, i) => tickPaths[i].hidden && 'hidden')
+                .attr('visibility', (d, i) => tickPaths[i].hidden ? 'hidden' : null)
                 .attr('d',
                     (d, i) => svgDomainLine(pathTranspose(tickPaths[i].path.map(withSign)))
                 );
 
             g.select('text')
-                .attr('visibility', (d, i) => labelOffsets[i].hidden && 'hidden')
+                .attr('visibility', (d, i) => labelOffsets[i].hidden ? 'hidden' : null)
                 .attr('transform', (d, i) => translate(...withSign(labelOffsets[i].offset)))
                 .attr('dy', () => {
                     let offset = '0em';


### PR DESCRIPTION
Two lines in `axisBase.js` use `&&` to conditionally set tick/label visibility, which returns `false` (not `null`) when the element is visible. Since D3's `.attr()` only removes attributes when the value is `null`, it stringifies `false` and sets `visibility="false"` — an invalid CSS value that triggers `Error in parsing value for 'visibility'. Declaration dropped.` on every re-render. On streaming charts with frequently updating ticks, this generates dozens of CSS parse errors.

Replaced `condition && 'hidden'` with `condition ? 'hidden' : null` so D3 correctly removes the attribute on visible elements.