### PR TITLE
fix(webgl): enable alpha blending by default in programBuilder

### DIFF
--- a/.changeset/fix-webgl-enable-blending.md
+++ b/.changeset/fix-webgl-enable-blending.md
@@ -1,0 +1,5 @@
+---
+'@d3fc/d3fc-webgl': patch
+---
+
+Enable alpha blending by default in WebGL program builder. Previously, RGBA alpha values in `webglFillColor` and `webglStrokeColor` had no effect on blending between WebGL elements because `gl.BLEND` was never enabled.

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -32,6 +32,9 @@ export default () => {
         }
         context.useProgram(program);
 
+        context.enable(context.BLEND);
+        context.blendFunc(context.SRC_ALPHA, context.ONE_MINUS_SRC_ALPHA);
+
         buffers.uniform(
             'uScreen',
             uniform([


### PR DESCRIPTION
`programBuilder.js` never calls `gl.enable(gl.BLEND)`, so RGBA alpha values in `webglFillColor` / `webglStrokeColor` have no effect on blending between WebGL elements drawn in the same canvas. The browser's canvas-to-page compositor does handle alpha against the HTML background, but overlapping WebGL elements within the GL context render opaquely on top of each other with no color mixing.

Adds standard alpha blending (`SRC_ALPHA` / `ONE_MINUS_SRC_ALPHA`) before draw calls. Two lines.

### Before

Blue bars paint over red with hard edges — no color mixing in overlap regions despite both series using alpha 0.6:

![Before](https://github.com/user-attachments/assets/d563b6d6-a080-45c8-ace4-2c9bcaa347b0)

### After

Overlap regions correctly blend to purple. Non-overlapping regions blend with the white background (also correct — alpha 0.6 means 40% of the background shows through):

![After](https://github.com/user-attachments/assets/633e3bfb-1de3-4ef6-ae86-5e83f2974c57)

Closes #1893