### PR TITLE
feat(webgl): add webglOpacity style helper

### DIFF
--- a/.changeset/add-webgl-opacity-helper.md
+++ b/.changeset/add-webgl-opacity-helper.md
@@ -1,0 +1,5 @@
+---
+'@d3fc/d3fc-webgl': minor
+---
+
+Add `webglOpacity` style helper for setting constant or per-datum opacity on WebGL series, independent of fill/stroke color alpha.

--- a/examples/series-webgl-opacity/README.md
+++ b/examples/series-webgl-opacity/README.md
@@ -1,0 +1,3 @@
+# Series WebGL Opacity
+
+Demonstrates the `webglOpacity` style helper with two overlapping bar series. The red series uses constant opacity; the blue series uses per-datum opacity that fades from left to right.

--- a/examples/series-webgl-opacity/__tests__/index.js
+++ b/examples/series-webgl-opacity/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/series-webgl-opacity/index.html
+++ b/examples/series-webgl-opacity/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <d3fc-canvas use-device-pixel-ratio set-webgl-viewport></d3fc-canvas>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/series-webgl-opacity/index.js
+++ b/examples/series-webgl-opacity/index.js
@@ -1,0 +1,99 @@
+// Demonstrates webglOpacity with two overlapping bar series.
+// The first series uses constant opacity; the second uses per-datum opacity.
+
+var redData = [];
+var blueData = [];
+for (var i = 0; i < 10; i++) {
+    redData.push({ x: i, y: 0.3 + Math.sin(i * 0.8) * 0.25 });
+    blueData.push({ x: i, y: 0.2 + Math.cos(i * 0.8) * 0.25 });
+}
+
+var xScale = d3.scaleLinear().domain([-0.5, 9.5]);
+var yScale = d3.scaleLinear().domain([0, 0.8]);
+var container = document.querySelector('d3fc-canvas');
+
+// -- Red series: constant opacity --
+// webglOpacity().value(number) sets a uniform opacity for the entire series.
+var redFill = fc.webglFillColor();
+var redOpacity = fc.webglOpacity();
+
+var redSeries = fc
+    .seriesWebglBar()
+    .xScale(xScale)
+    .yScale(yScale)
+    .crossValue(function(d) {
+        return d.x;
+    })
+    .mainValue(function(d) {
+        return d.y;
+    })
+    .bandwidth(150)
+    .defined(function() {
+        return true;
+    })
+    .equals(function(p) {
+        return p.length > 0;
+    })
+    .decorate(function(program) {
+        redFill
+            .value(function() {
+                return [0.9, 0.1, 0.1, 1];
+            })
+            .data(redData)(program);
+        // Constant opacity: every bar in this series is 60% opaque
+        redOpacity.value(0.6)(program);
+    });
+
+// -- Blue series: per-datum opacity --
+// webglOpacity().value(function) sets opacity per element.
+var blueFill = fc.webglFillColor();
+var blueOpacity = fc.webglOpacity();
+
+var blueSeries = fc
+    .seriesWebglBar()
+    .xScale(xScale)
+    .yScale(yScale)
+    .crossValue(function(d) {
+        return d.x;
+    })
+    .mainValue(function(d) {
+        return d.y;
+    })
+    .bandwidth(150)
+    .defined(function() {
+        return true;
+    })
+    .equals(function(p) {
+        return p.length > 0;
+    })
+    .decorate(function(program) {
+        blueFill
+            .value(function() {
+                return [0.1, 0.1, 0.9, 1];
+            })
+            .data(blueData)(program);
+        // Per-datum opacity: bars fade from opaque (left) to transparent (right)
+        blueOpacity
+            .value(function(d, i) {
+                return 1 - i / 12;
+            })
+            .data(blueData)(program);
+    });
+
+var gl = null;
+
+d3.select(container)
+    .on('measure', function(event) {
+        var detail = event.detail;
+        xScale.range([0, detail.width]);
+        yScale.range([detail.height, 0]);
+        gl = container.querySelector('canvas').getContext('webgl');
+        redSeries.context(gl);
+        blueSeries.context(gl);
+    })
+    .on('draw', function() {
+        redSeries(redData);
+        blueSeries(blueData);
+    });
+
+container.requestRedraw();

--- a/packages/d3fc-webgl/index.js
+++ b/packages/d3fc-webgl/index.js
@@ -28,3 +28,4 @@ export { default as webglSymbolMapper } from './src/symbolMapper';
 
 export { default as webglFillColor } from './src/style/fillColor';
 export { default as webglStrokeColor } from './src/style/strokeColor';
+export { default as webglOpacity } from './src/style/opacity';

--- a/packages/d3fc-webgl/src/program/programBuilder.js
+++ b/packages/d3fc-webgl/src/program/programBuilder.js
@@ -32,6 +32,9 @@ export default () => {
         }
         context.useProgram(program);
 
+        context.enable(context.BLEND);
+        context.blendFunc(context.SRC_ALPHA, context.ONE_MINUS_SRC_ALPHA);
+
         buffers.uniform(
             'uScreen',
             uniform([

--- a/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/fragmentShaderSnippets.js
@@ -279,3 +279,8 @@ export const strokeColor = {
     header: `varying vec4 vStrokeColor;`,
     body: `gl_FragColor = (canStroke * vStrokeColor) + ((1.0 - canStroke) * gl_FragColor);`
 };
+
+export const opacity = {
+    header: `varying float vOpacity;`,
+    body: `gl_FragColor = vec4(gl_FragColor.rgb, gl_FragColor.a * vOpacity);`
+};

--- a/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
+++ b/packages/d3fc-webgl/src/shaders/vertexShaderSnippets.js
@@ -26,6 +26,12 @@ export const strokeColor = {
     body: `vStrokeColor = aStrokeColor;`
 };
 
+export const opacity = {
+    header: `attribute float aOpacity;
+             varying float vOpacity;`,
+    body: `vOpacity = aOpacity;`
+};
+
 export const circle = {
     header: `
         attribute float aCrossValue;

--- a/packages/d3fc-webgl/src/style/opacity.js
+++ b/packages/d3fc-webgl/src/style/opacity.js
@@ -1,0 +1,57 @@
+import * as fragmentShaderSnippets from '../shaders/fragmentShaderSnippets';
+import * as vertexShaderSnippets from '../shaders/vertexShaderSnippets';
+import attribute from '../buffer/attribute';
+import constantAttribute from '../buffer/constantAttribute';
+import { rebind } from '@d3fc/d3fc-rebind';
+
+export default (initialValue = 1) => {
+    const projectedAttribute = attribute().size(1);
+
+    let value = initialValue;
+    let dirty = true;
+
+    const opacity = programBuilder => {
+        programBuilder
+            .vertexShader()
+            .appendHeaderIfNotExists(vertexShaderSnippets.opacity.header)
+            .appendBodyIfNotExists(vertexShaderSnippets.opacity.body);
+        programBuilder
+            .fragmentShader()
+            .appendHeaderIfNotExists(fragmentShaderSnippets.opacity.header)
+            .appendBodyIfNotExists(fragmentShaderSnippets.opacity.body);
+
+        if (typeof value === 'number') {
+            programBuilder
+                .buffers()
+                .attribute('aOpacity', constantAttribute([value]).size(1));
+        } else if (typeof value === 'function') {
+            if (!dirty) {
+                return;
+            }
+
+            projectedAttribute.value(value);
+            programBuilder.buffers().attribute('aOpacity', projectedAttribute);
+        } else {
+            throw new Error(
+                `Expected value to be a number or function, received ${value}`
+            );
+        }
+
+        dirty = false;
+    };
+
+    opacity.value = (...args) => {
+        if (!args.length) {
+            return value;
+        }
+        if (value !== args[0]) {
+            value = args[0];
+            dirty = true;
+        }
+        return opacity;
+    };
+
+    rebind(opacity, projectedAttribute, 'data');
+
+    return opacity;
+};


### PR DESCRIPTION
Adds a `webglOpacity()` style helper for WebGL series, providing opacity control independent of fill/stroke color. Supports both constant and per-datum values, matching the `webglFillColor` / `webglStrokeColor` API pattern.

### Usage

```js
// Constant opacity — entire series at 50%
const opacity = fc.webglOpacity();
series.decorate(program => {
    opacity.value(0.5)(program);
});

// Per-datum opacity — each element can have a different opacity
series.decorate(program => {
    opacity.value((d, i) => d.active ? 1.0 : 0.3).data(data)(program);
});
```

Opacity multiplies with the fill color's existing alpha channel — `fillColor([1, 0, 0, 0.5])` + `opacity(0.5)` produces effective alpha `0.25`.

Also includes `gl.enable(gl.BLEND)` in `programBuilder.js` (same as #1899, idempotent if that PR is merged first).

### Implementation

- New `opacity.js` style module in `d3fc-webgl/src/style/`
- Fragment shader snippet appended last — multiplies `gl_FragColor.a` by `vOpacity`
- Vertex shader snippet passes `aOpacity` attribute as `vOpacity` varying
- Constant values use `constantAttribute([value]).size(1)`, per-datum uses `attribute().size(1)` with the standard `attributeProjector` size-1 fast path
- Exported as `fc.webglOpacity` from `d3fc-webgl`

### Example

New example at `examples/series-webgl-opacity/` — red bars use constant 60% opacity, blue bars use per-datum opacity fading from opaque (left) to transparent (right). Overlap regions show correct alpha blending:

![webglOpacity example](https://github.com/user-attachments/assets/51ccfeaf-8daa-42e9-beb6-b8ee604244da)

Related: #1893