### PR TITLE
chore(deps): bump @babel/register from ^7.22.5 to ^7.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
             "devDependencies": {
                 "@babel/core": "^7.22.5",
                 "@babel/preset-env": "^7.22.5",
-                "@babel/register": "^7.22.5",
+                "@babel/register": "^7.28.0",
                 "@changesets/changelog-github": "^0.5.0",
                 "@changesets/cli": "^2.27.6",
                 "@commitlint/cli": "^19.3.0",
@@ -1732,15 +1732,15 @@
             }
         },
         "node_modules/@babel/register": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.5.tgz",
-            "integrity": "sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.28.6.tgz",
+            "integrity": "sha512-pgcbbEl/dWQYb6L6Yew6F94rdwygfuv+vJ/tXfwIOYAfPB6TNWpXUMEtEq3YuTeHRdvMIhvz13bkT9CNaS+wqA==",
             "dev": true,
             "dependencies": {
                 "clone-deep": "^4.0.1",
                 "find-cache-dir": "^2.0.0",
                 "make-dir": "^2.1.0",
-                "pirates": "^4.0.5",
+                "pirates": "^4.0.6",
                 "source-map-support": "^0.5.16"
             },
             "engines": {
@@ -25493,13 +25493,13 @@
             }
         },
         "packages/d3fc": {
-            "version": "15.2.12",
+            "version": "15.2.13",
             "license": "MIT",
             "dependencies": {
-                "@d3fc/d3fc-annotation": "^3.0.15",
+                "@d3fc/d3fc-annotation": "^3.0.16",
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-brush": "^3.0.3",
-                "@d3fc/d3fc-chart": "^5.1.8",
+                "@d3fc/d3fc-chart": "^5.1.9",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
                 "@d3fc/d3fc-element": "^6.2.0",
@@ -25511,21 +25511,21 @@
                 "@d3fc/d3fc-random-data": "^4.0.2",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-sample": "^5.0.2",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1",
                 "@d3fc/d3fc-technical-indicator": "^8.1.1",
-                "@d3fc/d3fc-webgl": "^3.2.0",
+                "@d3fc/d3fc-webgl": "^3.2.1",
                 "@d3fc/d3fc-zoom": "^1.2.0"
             }
         },
         "packages/d3fc-annotation": {
             "name": "@d3fc/d3fc-annotation",
-            "version": "3.0.15",
+            "version": "3.0.16",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1"
             },
             "peerDependencies": {
@@ -25564,14 +25564,14 @@
         },
         "packages/d3fc-chart": {
             "name": "@d3fc/d3fc-chart",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-element": "^6.2.0",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2"
+                "@d3fc/d3fc-series": "^6.1.3"
             },
             "peerDependencies": {
                 "d3-scale": "*",
@@ -25680,13 +25680,13 @@
         },
         "packages/d3fc-series": {
             "name": "@d3fc/d3fc-series",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-shape": "^6.0.1",
-                "@d3fc/d3fc-webgl": "^3.2.0"
+                "@d3fc/d3fc-webgl": "^3.2.1"
             },
             "peerDependencies": {
                 "d3-array": "*",
@@ -25717,7 +25717,7 @@
         },
         "packages/d3fc-webgl": {
             "name": "@d3fc/d3fc-webgl",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-rebind": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@babel/core": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
-        "@babel/register": "^7.22.5",
+        "@babel/register": "^7.28.0",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.6",
         "@commitlint/cli": "^19.3.0",


### PR DESCRIPTION
Semver minor bump within ^7 range. Build, tests, and lint all pass.