### PR TITLE
chore(deps): bump commitizen from ^4.3.0 to ^4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "babelrc-rollup": "^3.0.0",
                 "canvas": "^2.11.2",
                 "chalk": "^2.4.2",
-                "commitizen": "^4.3.0",
+                "commitizen": "^4.3.1",
                 "cz-conventional-changelog": "^3.0.2",
                 "d3": "^6.7.0",
                 "eslint": "^7.32.0",
@@ -8031,9 +8031,9 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/commitizen": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.0.tgz",
-            "integrity": "sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.1.tgz",
+            "integrity": "sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==",
             "dev": true,
             "dependencies": {
                 "cachedir": "2.3.0",
@@ -25493,13 +25493,13 @@
             }
         },
         "packages/d3fc": {
-            "version": "15.2.12",
+            "version": "15.2.13",
             "license": "MIT",
             "dependencies": {
-                "@d3fc/d3fc-annotation": "^3.0.15",
+                "@d3fc/d3fc-annotation": "^3.0.16",
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-brush": "^3.0.3",
-                "@d3fc/d3fc-chart": "^5.1.8",
+                "@d3fc/d3fc-chart": "^5.1.9",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
                 "@d3fc/d3fc-element": "^6.2.0",
@@ -25511,21 +25511,21 @@
                 "@d3fc/d3fc-random-data": "^4.0.2",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-sample": "^5.0.2",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1",
                 "@d3fc/d3fc-technical-indicator": "^8.1.1",
-                "@d3fc/d3fc-webgl": "^3.2.0",
+                "@d3fc/d3fc-webgl": "^3.2.1",
                 "@d3fc/d3fc-zoom": "^1.2.0"
             }
         },
         "packages/d3fc-annotation": {
             "name": "@d3fc/d3fc-annotation",
-            "version": "3.0.15",
+            "version": "3.0.16",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1"
             },
             "peerDependencies": {
@@ -25564,14 +25564,14 @@
         },
         "packages/d3fc-chart": {
             "name": "@d3fc/d3fc-chart",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-element": "^6.2.0",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2"
+                "@d3fc/d3fc-series": "^6.1.3"
             },
             "peerDependencies": {
                 "d3-scale": "*",
@@ -25680,13 +25680,13 @@
         },
         "packages/d3fc-series": {
             "name": "@d3fc/d3fc-series",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-shape": "^6.0.1",
-                "@d3fc/d3fc-webgl": "^3.2.0"
+                "@d3fc/d3fc-webgl": "^3.2.1"
             },
             "peerDependencies": {
                 "d3-array": "*",
@@ -25717,7 +25717,7 @@
         },
         "packages/d3fc-webgl": {
             "name": "@d3fc/d3fc-webgl",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-rebind": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "babelrc-rollup": "^3.0.0",
         "canvas": "^2.11.2",
         "chalk": "^2.4.2",
-        "commitizen": "^4.3.0",
+        "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.0.2",
         "d3": "^6.7.0",
         "eslint": "^7.32.0",


### PR DESCRIPTION
Patch bump. Build, tests, and lint all pass.