### PR TITLE
chore(deps): bump jest-image-snapshot from ^6.4.0 to ^6.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "glsl-transpiler": "^1.8.6",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.7.0",
-                "jest-image-snapshot": "^6.4.0",
+                "jest-image-snapshot": "^6.5.2",
                 "jest-puppeteer": "^10.0.1",
                 "js-combinatorics": "^0.5.5",
                 "jsdom": "^24.1.0",
@@ -15587,9 +15587,9 @@
             }
         },
         "node_modules/jest-image-snapshot": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/jest-image-snapshot/-/jest-image-snapshot-6.4.0.tgz",
-            "integrity": "sha512-IWGtSOnelwaVPd09STbJuLmnAwlBC/roJtTLGLb8M3TA0vfku3MRNEXmljTa1EMXqdRbA0oIWiqHFB1ttTGazQ==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/jest-image-snapshot/-/jest-image-snapshot-6.5.2.tgz",
+            "integrity": "sha512-frenWThr5ddnnokcX5N4gwi41hA5TiUOdhv/JoGcJrOaktHjrk4/7XbiHKW52lgKX+vei6QkRlgM7fkYQ15nPg==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
@@ -15598,14 +15598,13 @@
                 "lodash": "^4.17.4",
                 "pixelmatch": "^5.1.0",
                 "pngjs": "^3.4.0",
-                "rimraf": "^2.6.2",
                 "ssim.js": "^3.1.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             },
             "peerDependencies": {
-                "jest": ">=20 <=29"
+                "jest": ">=20 <31"
             },
             "peerDependenciesMeta": {
                 "jest": {
@@ -22554,18 +22553,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
         "node_modules/rollup": {
             "version": "2.79.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -25493,13 +25480,13 @@
             }
         },
         "packages/d3fc": {
-            "version": "15.2.12",
+            "version": "15.2.13",
             "license": "MIT",
             "dependencies": {
-                "@d3fc/d3fc-annotation": "^3.0.15",
+                "@d3fc/d3fc-annotation": "^3.0.16",
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-brush": "^3.0.3",
-                "@d3fc/d3fc-chart": "^5.1.8",
+                "@d3fc/d3fc-chart": "^5.1.9",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
                 "@d3fc/d3fc-element": "^6.2.0",
@@ -25511,21 +25498,21 @@
                 "@d3fc/d3fc-random-data": "^4.0.2",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-sample": "^5.0.2",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1",
                 "@d3fc/d3fc-technical-indicator": "^8.1.1",
-                "@d3fc/d3fc-webgl": "^3.2.0",
+                "@d3fc/d3fc-webgl": "^3.2.1",
                 "@d3fc/d3fc-zoom": "^1.2.0"
             }
         },
         "packages/d3fc-annotation": {
             "name": "@d3fc/d3fc-annotation",
-            "version": "3.0.15",
+            "version": "3.0.16",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1"
             },
             "peerDependencies": {
@@ -25564,14 +25551,14 @@
         },
         "packages/d3fc-chart": {
             "name": "@d3fc/d3fc-chart",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-element": "^6.2.0",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2"
+                "@d3fc/d3fc-series": "^6.1.3"
             },
             "peerDependencies": {
                 "d3-scale": "*",
@@ -25680,13 +25667,13 @@
         },
         "packages/d3fc-series": {
             "name": "@d3fc/d3fc-series",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-shape": "^6.0.1",
-                "@d3fc/d3fc-webgl": "^3.2.0"
+                "@d3fc/d3fc-webgl": "^3.2.1"
             },
             "peerDependencies": {
                 "d3-array": "*",
@@ -25717,7 +25704,7 @@
         },
         "packages/d3fc-webgl": {
             "name": "@d3fc/d3fc-webgl",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-rebind": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "glsl-transpiler": "^1.8.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "jest-image-snapshot": "^6.4.0",
+        "jest-image-snapshot": "^6.5.2",
         "jest-puppeteer": "^10.0.1",
         "js-combinatorics": "^0.5.5",
         "jsdom": "^24.1.0",


### PR DESCRIPTION
Patch bump. Build, tests, and lint all pass.