### PR TITLE
fix(deps): upgrade puppeteer from ^22.8.0 to ^24.0.0 and fix deprecated page.waitFor()

### DIFF
--- a/examples/__helpers__/waitForEmptyRedrawQueue.js
+++ b/examples/__helpers__/waitForEmptyRedrawQueue.js
@@ -1,3 +1,3 @@
 module.exports.waitForEmptyRedrawQueue = async () => {
-    await page.waitFor(() => document['__d3fc-elements__'] == null);
+    await page.waitForFunction(() => document['__d3fc-elements__'] == null);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "markdownlint-cli": "^0.17.0",
                 "mockdate": "^2.0.5",
                 "prettier": "^1.19.1",
-                "puppeteer": "^22.8.0",
+                "puppeteer": "^24.0.0",
                 "rollup": "^2.79.1",
                 "rollup-plugin-livereload": "^2.0.5",
                 "rollup-plugin-serve": "^1.1.0",
@@ -5405,19 +5405,18 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
-            "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+            "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
             "dev": true,
             "dependencies": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "progress": "2.0.3",
-                "proxy-agent": "6.4.0",
-                "semver": "7.6.0",
-                "tar-fs": "3.0.5",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
+                "debug": "^4.4.3",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.5.0",
+                "semver": "^7.7.4",
+                "tar-fs": "^3.1.1",
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
@@ -5426,38 +5425,17 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@puppeteer/browsers/node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
         },
         "node_modules/@rollup/plugin-babel": {
             "version": "6.0.4",
@@ -7081,10 +7059,18 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
-            "dev": true
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+            "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+            "dev": true,
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -7318,49 +7304,94 @@
             "dev": true
         },
         "node_modules/bare-events": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+            "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
             "dev": true,
-            "optional": true
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/bare-fs": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
-            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+            "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
             "dev": true,
-            "optional": true,
             "dependencies": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^2.0.0",
-                "bare-stream": "^2.0.0"
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
             }
         },
         "node_modules/bare-os": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
-            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "version": "3.8.7",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+            "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
             "dev": true,
-            "optional": true
+            "engines": {
+                "bare": ">=1.14.0"
+            }
         },
         "node_modules/bare-path": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "dev": true,
-            "optional": true,
             "dependencies": {
-                "bare-os": "^2.1.0"
+                "bare-os": "^3.0.1"
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
-            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+            "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
             "dev": true,
-            "optional": true,
             "dependencies": {
-                "streamx": "^2.18.0"
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
+            },
+            "peerDependencies": {
+                "bare-abort-controller": "*",
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
+                "bare-buffer": {
+                    "optional": true
+                },
+                "bare-events": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-url": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+            "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+            "dev": true,
+            "dependencies": {
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/base64-js": {
@@ -7384,9 +7415,9 @@
             ]
         },
         "node_modules/basic-ftp": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -7838,14 +7869,13 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.5.23",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.23.tgz",
-            "integrity": "sha512-1o/gLU9wDqbN5nL2MtfjykjOuighGXc3/hnWueO1haiEoFgX8h5vbvcA4tgdQfjw1mkZ1OEF4x/+HVeqEX6NoA==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+            "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
             "dev": true,
             "dependencies": {
-                "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.23.8"
+                "mitt": "^3.0.1",
+                "zod": "^3.24.1"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -9832,12 +9862,12 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -10046,9 +10076,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1299070",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1299070.tgz",
-            "integrity": "sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg==",
+            "version": "0.0.1595872",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+            "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
             "dev": true
         },
         "node_modules/diff-sequences": {
@@ -11176,6 +11206,15 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "dev": true,
+            "dependencies": {
+                "bare-events": "^2.7.0"
+            }
         },
         "node_modules/execa": {
             "version": "8.0.1",
@@ -12316,32 +12355,17 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
             "dev": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/get-uri/node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/git-raw-commits": {
@@ -13620,29 +13644,13 @@
             "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
         },
         "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
             "dev": true,
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
             "engines": {
                 "node": ">= 12"
             }
-        },
-        "node_modules/ip-address/node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "dev": true
-        },
-        "node_modules/ip-address/node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true
         },
         "node_modules/irregular-plurals": {
             "version": "3.5.0",
@@ -18919,9 +18927,9 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "node_modules/multimatch": {
@@ -18986,9 +18994,9 @@
             "dev": true
         },
         "node_modules/netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+            "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
@@ -20642,43 +20650,40 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "dev": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
-                "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.2"
+                "https-proxy-agent": "^7.0.6",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
@@ -21709,43 +21714,40 @@
             "dev": true
         },
         "node_modules/proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "dev": true,
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
+                "pac-proxy-agent": "^7.1.0",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/proxy-agent/node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
@@ -21780,9 +21782,9 @@
             "dev": true
         },
         "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
             "dev": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -21799,55 +21801,42 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "22.11.2",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.11.2.tgz",
-            "integrity": "sha512-8fjdQSgW0sq7471ftca24J7sXK+jXZ7OW7Gx+NEBFNyXrcTiBfukEI46gNq6hiMhbLEDT30NeylK/1ZoPdlKSA==",
+            "version": "24.41.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.41.0.tgz",
+            "integrity": "sha512-W6Fk0J3TPjjtwjXOyR/qf+YaL0H/Uq8HIgHcXG4mNM/IgbKMCH/HPyK0Fi2qbTU/QpSl9bCte2yBpGHKejTpIw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@puppeteer/browsers": "2.2.3",
-                "cosmiconfig": "9.0.0",
-                "devtools-protocol": "0.0.1299070",
-                "puppeteer-core": "22.11.2"
+                "@puppeteer/browsers": "2.13.0",
+                "chromium-bidi": "14.0.0",
+                "cosmiconfig": "^9.0.0",
+                "devtools-protocol": "0.0.1595872",
+                "puppeteer-core": "24.41.0",
+                "typed-query-selector": "^2.12.1"
             },
             "bin": {
-                "puppeteer": "lib/esm/puppeteer/node/cli.js"
+                "puppeteer": "lib/cjs/puppeteer/node/cli.js"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "22.11.2",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.11.2.tgz",
-            "integrity": "sha512-vQo+YDuePyvj+92Z9cdtxi/HalKf+k/R4tE80nGtQqJRNqU81eHaHkbVfnLszdaLlvwFF5tipnnSCzqWlEddtw==",
+            "version": "24.41.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.41.0.tgz",
+            "integrity": "sha512-rLIUri7E/NQ3APSEYCCozaSJx0u8Tu9wxO6BJwnvXmIgILSK3L0TombaVh3izp1njAGrO6H2ru0hcIrLF+gWLw==",
             "dev": true,
             "dependencies": {
-                "@puppeteer/browsers": "2.2.3",
-                "chromium-bidi": "0.5.23",
-                "debug": "4.3.5",
-                "devtools-protocol": "0.0.1299070",
-                "ws": "8.17.1"
+                "@puppeteer/browsers": "2.13.0",
+                "chromium-bidi": "14.0.0",
+                "debug": "^4.4.3",
+                "devtools-protocol": "0.0.1595872",
+                "typed-query-selector": "^2.12.1",
+                "webdriver-bidi-protocol": "0.4.1",
+                "ws": "^8.19.0"
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/pure-rand": {
@@ -21891,12 +21880,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/queue-tick": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-            "dev": true
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -23125,12 +23108,12 @@
             "dev": true
         },
         "node_modules/socks": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
-            "integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "dev": true,
             "dependencies": {
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -23139,27 +23122,24 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "dev": true,
             "dependencies": {
-                "agent-base": "^7.1.1",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
-                "socks": "^2.7.1"
+                "socks": "^2.8.3"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/socks-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
             "engines": {
                 "node": ">= 14"
             }
@@ -23407,17 +23387,14 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
-            "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+            "version": "2.25.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+            "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
             "dev": true,
             "dependencies": {
+                "events-universal": "^1.0.0",
                 "fast-fifo": "^1.3.2",
-                "queue-tick": "^1.0.1",
                 "text-decoder": "^1.1.0"
-            },
-            "optionalDependencies": {
-                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {
@@ -23708,26 +23685,27 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-            "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
             "dev": true,
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
             },
             "optionalDependencies": {
-                "bare-fs": "^2.1.1",
-                "bare-path": "^2.1.0"
+                "bare-fs": "^4.0.1",
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/tar-fs/node_modules/tar-stream": {
-            "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+            "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
             "dev": true,
             "dependencies": {
                 "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
@@ -23774,6 +23752,15 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+            "dev": true,
+            "dependencies": {
+                "streamx": "^2.12.5"
+            }
         },
         "node_modules/temp-dir": {
             "version": "1.0.0",
@@ -23841,9 +23828,9 @@
             }
         },
         "node_modules/text-decoder": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.0.tgz",
-            "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
             "dev": true,
             "dependencies": {
                 "b4a": "^1.6.4"
@@ -24708,6 +24695,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/typed-query-selector": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+            "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+            "dev": true
+        },
         "node_modules/typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -24760,22 +24753,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
-        },
-        "node_modules/unbzip2-stream/node_modules/through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-            "dev": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -24927,12 +24904,6 @@
                 "requires-port": "^1.0.0"
             }
         },
-        "node_modules/urlpattern-polyfill": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-            "dev": true
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -25038,6 +25009,12 @@
             "dependencies": {
                 "defaults": "^1.0.3"
             }
+        },
+        "node_modules/webdriver-bidi-protocol": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+            "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+            "dev": true
         },
         "node_modules/webidl-conversions": {
             "version": "7.0.0",
@@ -25375,9 +25352,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -25484,22 +25461,22 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.23.8",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "packages/d3fc": {
-            "version": "15.2.12",
+            "version": "15.2.13",
             "license": "MIT",
             "dependencies": {
-                "@d3fc/d3fc-annotation": "^3.0.15",
+                "@d3fc/d3fc-annotation": "^3.0.16",
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-brush": "^3.0.3",
-                "@d3fc/d3fc-chart": "^5.1.8",
+                "@d3fc/d3fc-chart": "^5.1.9",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
                 "@d3fc/d3fc-element": "^6.2.0",
@@ -25511,21 +25488,21 @@
                 "@d3fc/d3fc-random-data": "^4.0.2",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-sample": "^5.0.2",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1",
                 "@d3fc/d3fc-technical-indicator": "^8.1.1",
-                "@d3fc/d3fc-webgl": "^3.2.0",
+                "@d3fc/d3fc-webgl": "^3.2.1",
                 "@d3fc/d3fc-zoom": "^1.2.0"
             }
         },
         "packages/d3fc-annotation": {
             "name": "@d3fc/d3fc-annotation",
-            "version": "3.0.15",
+            "version": "3.0.16",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1"
             },
             "peerDependencies": {
@@ -25564,14 +25541,14 @@
         },
         "packages/d3fc-chart": {
             "name": "@d3fc/d3fc-chart",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-element": "^6.2.0",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2"
+                "@d3fc/d3fc-series": "^6.1.3"
             },
             "peerDependencies": {
                 "d3-scale": "*",
@@ -25680,13 +25657,13 @@
         },
         "packages/d3fc-series": {
             "name": "@d3fc/d3fc-series",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-shape": "^6.0.1",
-                "@d3fc/d3fc-webgl": "^3.2.0"
+                "@d3fc/d3fc-webgl": "^3.2.1"
             },
             "peerDependencies": {
                 "d3-array": "*",
@@ -25717,7 +25694,7 @@
         },
         "packages/d3fc-webgl": {
             "name": "@d3fc/d3fc-webgl",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-rebind": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "markdownlint-cli": "^0.17.0",
         "mockdate": "^2.0.5",
         "prettier": "^1.19.1",
-        "puppeteer": "^22.8.0",
+        "puppeteer": "^24.0.0",
         "rollup": "^2.79.1",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^1.1.0",


### PR DESCRIPTION
Upgrades puppeteer from v22 to v24, addressing critical/high vulnerabilities in @puppeteer/browsers.

Also fixes a pre-existing bug: `page.waitFor()` was removed in puppeteer 22.0.0, but `examples/__helpers__/waitForEmptyRedrawQueue.js` still used it. Replaced with the equivalent `page.waitForFunction()`.

Note: puppeteer 23+ changed `page.screenshot()` to return `Uint8Array` instead of `Buffer`. The unit test suite passes; the example screenshot tests (jest-image-snapshot) should be verified in CI to confirm `Uint8Array` compatibility.

Build, tests (377/377), and lint all pass.