### PR TITLE
chore(deps): upgrade mockdate from ^2.0.5 to ^3.0.5

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: "Run tests"
         run: npm test
+        env:
+          TZ: UTC
 
   lint:
     name: Code standards

--- a/examples/annotation-canvas-band/index.html
+++ b/examples/annotation-canvas-band/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-canvas-crosshair/index.html
+++ b/examples/annotation-canvas-crosshair/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-canvas-gridline/index.html
+++ b/examples/annotation-canvas-gridline/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-canvas-line/index.html
+++ b/examples/annotation-canvas-line/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-gridline-transition/index.html
+++ b/examples/annotation-gridline-transition/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-svg-band/index.html
+++ b/examples/annotation-svg-band/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-svg-crosshair/index.html
+++ b/examples/annotation-svg-crosshair/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-svg-gridline/index.html
+++ b/examples/annotation-svg-gridline/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/annotation-svg-line/index.html
+++ b/examples/annotation-svg-line/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-annotation/index.html
+++ b/examples/axis-annotation/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-band-scale/index.html
+++ b/examples/axis-band-scale/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-center/index.html
+++ b/examples/axis-center/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-color/index.html
+++ b/examples/axis-color/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-label-offset/index.html
+++ b/examples/axis-label-offset/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-offset/index.html
+++ b/examples/axis-offset/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-rotate-auto/index.html
+++ b/examples/axis-rotate-auto/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-rotate-decorate/index.html
+++ b/examples/axis-rotate-decorate/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-tick-arguments/index.html
+++ b/examples/axis-tick-arguments/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/axis-transition/index.html
+++ b/examples/axis-transition/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/bar-chart-race/index.html
+++ b/examples/bar-chart-race/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/boxplot/index.html
+++ b/examples/boxplot/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/brush-navigator/index.html
+++ b/examples/brush-navigator/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/brush-zoom/index.html
+++ b/examples/brush-zoom/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/bubble-chart/index.html
+++ b/examples/bubble-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/building-a-chart/index.html
+++ b/examples/building-a-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-cartesian-custom-axis/index.html
+++ b/examples/chart-cartesian-custom-axis/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-cartesian-move-axis/index.html
+++ b/examples/chart-cartesian-move-axis/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-cartesian-ordinal/index.html
+++ b/examples/chart-cartesian-ordinal/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-cartesian-second-axis/index.html
+++ b/examples/chart-cartesian-second-axis/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-cartesian-transition/index.html
+++ b/examples/chart-cartesian-transition/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-d3-zoom/index.html
+++ b/examples/chart-d3-zoom/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-d3fc-zoom/index.html
+++ b/examples/chart-d3fc-zoom/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/chart-deprecated/index.html
+++ b/examples/chart-deprecated/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/diamonds/index.html
+++ b/examples/diamonds/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/discontinuous-axis/index.html
+++ b/examples/discontinuous-axis/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/discontinuous-week-axis/index.html
+++ b/examples/discontinuous-week-axis/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/earth-and-mars/index.html
+++ b/examples/earth-and-mars/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/element-bespoke-chart-layout/index.html
+++ b/examples/element-bespoke-chart-layout/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/idempotent-streaming-chart/index.html
+++ b/examples/idempotent-streaming-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/interactive-small-multiples/index.html
+++ b/examples/interactive-small-multiples/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/label-layout-chart/index.html
+++ b/examples/label-layout-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/label-layout/index.html
+++ b/examples/label-layout/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/marathon-pace/index.html
+++ b/examples/marathon-pace/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/sample/index.html
+++ b/examples/sample/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-area/index.html
+++ b/examples/series-canvas-area/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-auto-bandwidth/index.html
+++ b/examples/series-canvas-auto-bandwidth/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-bar/index.html
+++ b/examples/series-canvas-bar/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-boxplot/index.html
+++ b/examples/series-canvas-boxplot/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-candlestick/index.html
+++ b/examples/series-canvas-candlestick/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-decorate-append/index.html
+++ b/examples/series-canvas-decorate-append/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-decorate/index.html
+++ b/examples/series-canvas-decorate/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-errorbar/index.html
+++ b/examples/series-canvas-errorbar/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-grouped/index.html
+++ b/examples/series-canvas-grouped/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-heatmap/index.html
+++ b/examples/series-canvas-heatmap/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-line/index.html
+++ b/examples/series-canvas-line/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-multi/index.html
+++ b/examples/series-canvas-multi/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-ohlc/index.html
+++ b/examples/series-canvas-ohlc/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-point-size-type/index.html
+++ b/examples/series-canvas-point-size-type/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-point/index.html
+++ b/examples/series-canvas-point/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-repeat/index.html
+++ b/examples/series-canvas-repeat/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-canvas-stacked/index.html
+++ b/examples/series-canvas-stacked/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-area/index.html
+++ b/examples/series-svg-area/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-auto-bandwidth/index.html
+++ b/examples/series-svg-auto-bandwidth/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-bar/index.html
+++ b/examples/series-svg-bar/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-boxplot/index.html
+++ b/examples/series-svg-boxplot/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-candlestick/index.html
+++ b/examples/series-svg-candlestick/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-decorate-append/index.html
+++ b/examples/series-svg-decorate-append/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-decorate/index.html
+++ b/examples/series-svg-decorate/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-errorbar/index.html
+++ b/examples/series-svg-errorbar/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-grouped-alternate/index.html
+++ b/examples/series-svg-grouped-alternate/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-grouped/index.html
+++ b/examples/series-svg-grouped/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-heatmap/index.html
+++ b/examples/series-svg-heatmap/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-line/index.html
+++ b/examples/series-svg-line/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-multi/index.html
+++ b/examples/series-svg-multi/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-ohlc/index.html
+++ b/examples/series-svg-ohlc/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-point-size-type/index.html
+++ b/examples/series-svg-point-size-type/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-point/index.html
+++ b/examples/series-svg-point/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-repeat/index.html
+++ b/examples/series-svg-repeat/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-svg-stacked/index.html
+++ b/examples/series-svg-stacked/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-area/index.html
+++ b/examples/series-webgl-area/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-bar/index.html
+++ b/examples/series-webgl-bar/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-boxplot/index.html
+++ b/examples/series-webgl-boxplot/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-candlestick/index.html
+++ b/examples/series-webgl-candlestick/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-errorbar/index.html
+++ b/examples/series-webgl-errorbar/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-line/index.html
+++ b/examples/series-webgl-line/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-multi/index.html
+++ b/examples/series-webgl-multi/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-ohlc/index.html
+++ b/examples/series-webgl-ohlc/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-point/index.html
+++ b/examples/series-webgl-point/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-repeat/index.html
+++ b/examples/series-webgl-repeat/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/series-webgl-stacked/index.html
+++ b/examples/series-webgl-stacked/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/simple-chart/index.html
+++ b/examples/simple-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/small-multiples/index.html
+++ b/examples/small-multiples/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/stacked-bar-chart/index.html
+++ b/examples/stacked-bar-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/streaming-chart/index.html
+++ b/examples/streaming-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/svg-canvas-and-webgl-chart/index.html
+++ b/examples/svg-canvas-and-webgl-chart/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-bollinger-bands-canvas/index.html
+++ b/examples/technical-indicator-bollinger-bands-canvas/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-bollinger-bands-svg/index.html
+++ b/examples/technical-indicator-bollinger-bands-svg/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-elder-ray/index.html
+++ b/examples/technical-indicator-elder-ray/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-envelope/index.html
+++ b/examples/technical-indicator-envelope/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-force-index/index.html
+++ b/examples/technical-indicator-force-index/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-macd/index.html
+++ b/examples/technical-indicator-macd/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-relative-strength-index/index.html
+++ b/examples/technical-indicator-relative-strength-index/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/technical-indicator-stochastic-oscillator/index.html
+++ b/examples/technical-indicator-stochastic-oscillator/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/transitions/index.html
+++ b/examples/transitions/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/webgl-context-lost/index.html
+++ b/examples/webgl-context-lost/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/examples/webgl-with-svg-overlay/index.html
+++ b/examples/webgl-with-svg-overlay/index.html
@@ -3,8 +3,8 @@
 <head>
     <script src="../../node_modules/seedrandom/seedrandom.js"></script>
     <script>Math.seedrandom('a22ebc7c488a3a47');</script>
-    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
-    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/mockdate/lib/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01');</script>
     <script src="../../node_modules/d3/dist/d3.js"></script>
     <script src="../../packages/d3fc/build/d3fc.js"></script>
     <script src="../index.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "lerna": "^8.1.2",
                 "markdownlint": "^0.16.0",
                 "markdownlint-cli": "^0.17.0",
-                "mockdate": "^2.0.5",
+                "mockdate": "^3.0.5",
                 "prettier": "^1.19.1",
                 "puppeteer": "^22.8.0",
                 "rollup": "^2.79.1",
@@ -18895,9 +18895,9 @@
             "dev": true
         },
         "node_modules/mockdate": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-2.0.5.tgz",
-            "integrity": "sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+            "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
             "dev": true
         },
         "node_modules/modify-values": {
@@ -25493,13 +25493,13 @@
             }
         },
         "packages/d3fc": {
-            "version": "15.2.12",
+            "version": "15.2.13",
             "license": "MIT",
             "dependencies": {
-                "@d3fc/d3fc-annotation": "^3.0.15",
+                "@d3fc/d3fc-annotation": "^3.0.16",
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-brush": "^3.0.3",
-                "@d3fc/d3fc-chart": "^5.1.8",
+                "@d3fc/d3fc-chart": "^5.1.9",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
                 "@d3fc/d3fc-element": "^6.2.0",
@@ -25511,21 +25511,21 @@
                 "@d3fc/d3fc-random-data": "^4.0.2",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-sample": "^5.0.2",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1",
                 "@d3fc/d3fc-technical-indicator": "^8.1.1",
-                "@d3fc/d3fc-webgl": "^3.2.0",
+                "@d3fc/d3fc-webgl": "^3.2.1",
                 "@d3fc/d3fc-zoom": "^1.2.0"
             }
         },
         "packages/d3fc-annotation": {
             "name": "@d3fc/d3fc-annotation",
-            "version": "3.0.15",
+            "version": "3.0.16",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1"
             },
             "peerDependencies": {
@@ -25564,14 +25564,14 @@
         },
         "packages/d3fc-chart": {
             "name": "@d3fc/d3fc-chart",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-element": "^6.2.0",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2"
+                "@d3fc/d3fc-series": "^6.1.3"
             },
             "peerDependencies": {
                 "d3-scale": "*",
@@ -25680,13 +25680,13 @@
         },
         "packages/d3fc-series": {
             "name": "@d3fc/d3fc-series",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-shape": "^6.0.1",
-                "@d3fc/d3fc-webgl": "^3.2.0"
+                "@d3fc/d3fc-webgl": "^3.2.1"
             },
             "peerDependencies": {
                 "d3-array": "*",
@@ -25717,7 +25717,7 @@
         },
         "packages/d3fc-webgl": {
             "name": "@d3fc/d3fc-webgl",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-rebind": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "lerna": "^8.1.2",
         "markdownlint": "^0.16.0",
         "markdownlint-cli": "^0.17.0",
-        "mockdate": "^2.0.5",
+        "mockdate": "^3.0.5",
         "prettier": "^1.19.1",
         "puppeteer": "^22.8.0",
         "rollup": "^2.79.1",

--- a/scripts/site.sh
+++ b/scripts/site.sh
@@ -8,7 +8,7 @@ cp -r ../examples .
 # update scripts to reference unpkg 
 # N.B. these versions need to be kept in sync with package.json
 sed -i "s#../../node_modules/seedrandom#https://unpkg.com/seedrandom@3#" examples/*/index.html
-sed -i "s#../../node_modules/mockdate#https://unpkg.com/mockdate@2#" examples/*/index.html
+sed -i "s#../../node_modules/mockdate#https://unpkg.com/mockdate@3#" examples/*/index.html
 sed -i "s#../../node_modules/d3#https://unpkg.com/d3#" examples/*/index.html
 sed -i "s#../../node_modules/#https://unpkg.com/#" examples/*/index.html
 sed -i "s#../../packages/#https://unpkg.com/#" examples/*/index.html


### PR DESCRIPTION
Upgrades mockdate from v2 to v3. Two breaking changes required mechanical updates across 106 example HTML files:

1. **File path changed**: `src/mockdate.js` → `lib/mockdate.js`
2. **Timezone offset parameter removed**: `MockDate.set('2000-01-01', 0)` → `MockDate.set('2000-01-01')`

The timezone offset parameter (second arg `0`) forced UTC for deterministic screenshot tests. Mockdate 3 dropped this parameter, so we add `TZ=UTC` as an environment variable on the CI test step — a more robust approach since it affects all date/time operations at the OS level, not just `getTimezoneOffset()`.

Also updates `scripts/site.sh` unpkg URL from `mockdate@2` to `mockdate@3`.

The diff is large (110 files) but every example change is an identical 2-line mechanical replacement. Build, tests (377/377), and lint all pass.