### PR TITLE
chore(ci): bump Node version from 20.15.0 to 20.19.0

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Setup Node"
         uses: actions/setup-node@v4
         with:
-          node-version: 20.15.0
+          node-version: 20.19.0
 
       - name: "Install dependencies"
         run: npm ci
@@ -45,7 +45,7 @@ jobs:
       - name: "Setup Node"
         uses: actions/setup-node@v4
         with:
-          node-version: 20.15.0
+          node-version: 20.19.0
 
       - name: "Install dependencies"
         run: npm ci


### PR DESCRIPTION
## Summary
- Bumps the pinned Node version in CI from 20.15.0 to 20.19.0
- Node 20.19.0 is required by upcoming dependency upgrades (jest-environment-jsdom 30, lerna 9, jsdom 29) which need APIs introduced after 20.15.0
- Both the `build-test` and `lint` jobs are updated

## Test plan
- [x] `npm ci` — clean install succeeds
- [x] `npm run bundle` — all 21 packages build
- [x] `npm run bundle-min` — minified builds succeed
- [x] `npm test` — all tests pass
- [x] `npm run lint` — ESLint + markdownlint clean