### PR TITLE
chore: remove unused chalk dependency and dead commit-notice script

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
         "@typescript-eslint/parser": "^4.33.0",
         "babelrc-rollup": "^3.0.0",
         "canvas": "^2.11.2",
-        "chalk": "^2.4.2",
         "commitizen": "^4.3.0",
         "cz-conventional-changelog": "^3.0.2",
         "d3": "^6.7.0",

--- a/scripts/commit-notice.js
+++ b/scripts/commit-notice.js
@@ -1,8 +1,0 @@
-const chalk = require('chalk');
-
-// eslint-disable-next-line no-console
-console.log(
-    'All commits should be accompanied by conventional commit messages. You can easily generate an appropriate message by instead using ' +
-        chalk.blue('`npx git-cz`') +
-        '.'
-);


### PR DESCRIPTION
## Summary
- Remove `chalk@^2.4.2` from devDependencies
- Delete `scripts/commit-notice.js` — an unreferenced script that prints a "use `npx git-cz`" message with chalk coloring

The script is not wired to any npm script, git hook, or config file. It appears to be a leftover from a previous husky setup. chalk has no other direct consumers in the codebase.

No changeset — devDependency removal only, no published package changes.

## Test plan
- [x] `npm ci` — clean install succeeds
- [x] `npm run bundle` — all 21 packages build
- [x] `npm run bundle-min` — minified builds succeed
- [x] `npm test` — all tests pass
- [x] `npm run lint` — clean