### PR TITLE
chore(deps): upgrade rollup from 2.x to 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "mockdate": "^2.0.5",
                 "prettier": "^1.19.1",
                 "puppeteer": "^22.8.0",
-                "rollup": "^2.79.1",
+                "rollup": "^4.0.0",
                 "rollup-plugin-livereload": "^2.0.5",
                 "rollup-plugin-serve": "^1.1.0",
                 "seedrandom": "^3.0.5",
@@ -5566,6 +5566,331 @@
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
             "dev": true
         },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+            "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+            "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+            "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+            "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+            "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+            "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+            "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+            "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+            "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+            "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+            "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+            "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+            "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+            "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+            "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+            "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+            "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+            "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+            "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+            "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+            "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+            "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+            "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+            "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+            "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -6279,9 +6604,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true
         },
         "node_modules/@types/geojson": {
@@ -22567,17 +22892,46 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.79.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-            "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+            "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
             "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.60.1",
+                "@rollup/rollup-android-arm64": "4.60.1",
+                "@rollup/rollup-darwin-arm64": "4.60.1",
+                "@rollup/rollup-darwin-x64": "4.60.1",
+                "@rollup/rollup-freebsd-arm64": "4.60.1",
+                "@rollup/rollup-freebsd-x64": "4.60.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+                "@rollup/rollup-linux-arm64-musl": "4.60.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+                "@rollup/rollup-linux-loong64-musl": "4.60.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+                "@rollup/rollup-linux-x64-gnu": "4.60.1",
+                "@rollup/rollup-linux-x64-musl": "4.60.1",
+                "@rollup/rollup-openbsd-x64": "4.60.1",
+                "@rollup/rollup-openharmony-arm64": "4.60.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+                "@rollup/rollup-win32-x64-gnu": "4.60.1",
+                "@rollup/rollup-win32-x64-msvc": "4.60.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -25493,13 +25847,13 @@
             }
         },
         "packages/d3fc": {
-            "version": "15.2.12",
+            "version": "15.2.13",
             "license": "MIT",
             "dependencies": {
-                "@d3fc/d3fc-annotation": "^3.0.15",
+                "@d3fc/d3fc-annotation": "^3.0.16",
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-brush": "^3.0.3",
-                "@d3fc/d3fc-chart": "^5.1.8",
+                "@d3fc/d3fc-chart": "^5.1.9",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-discontinuous-scale": "^4.1.1",
                 "@d3fc/d3fc-element": "^6.2.0",
@@ -25511,21 +25865,21 @@
                 "@d3fc/d3fc-random-data": "^4.0.2",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-sample": "^5.0.2",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1",
                 "@d3fc/d3fc-technical-indicator": "^8.1.1",
-                "@d3fc/d3fc-webgl": "^3.2.0",
+                "@d3fc/d3fc-webgl": "^3.2.1",
                 "@d3fc/d3fc-zoom": "^1.2.0"
             }
         },
         "packages/d3fc-annotation": {
             "name": "@d3fc/d3fc-annotation",
-            "version": "3.0.15",
+            "version": "3.0.16",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2",
+                "@d3fc/d3fc-series": "^6.1.3",
                 "@d3fc/d3fc-shape": "^6.0.1"
             },
             "peerDependencies": {
@@ -25564,14 +25918,14 @@
         },
         "packages/d3fc-chart": {
             "name": "@d3fc/d3fc-chart",
-            "version": "5.1.8",
+            "version": "5.1.9",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-axis": "^3.0.7",
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-element": "^6.2.0",
                 "@d3fc/d3fc-rebind": "^6.0.1",
-                "@d3fc/d3fc-series": "^6.1.2"
+                "@d3fc/d3fc-series": "^6.1.3"
             },
             "peerDependencies": {
                 "d3-scale": "*",
@@ -25680,13 +26034,13 @@
         },
         "packages/d3fc-series": {
             "name": "@d3fc/d3fc-series",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-data-join": "^6.0.3",
                 "@d3fc/d3fc-rebind": "^6.0.1",
                 "@d3fc/d3fc-shape": "^6.0.1",
-                "@d3fc/d3fc-webgl": "^3.2.0"
+                "@d3fc/d3fc-webgl": "^3.2.1"
             },
             "peerDependencies": {
                 "d3-array": "*",
@@ -25717,7 +26071,7 @@
         },
         "packages/d3fc-webgl": {
             "name": "@d3fc/d3fc-webgl",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@d3fc/d3fc-rebind": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "mockdate": "^2.0.5",
         "prettier": "^1.19.1",
         "puppeteer": "^22.8.0",
-        "rollup": "^2.79.1",
+        "rollup": "^4.0.0",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^1.1.0",
         "seedrandom": "^3.0.5",

--- a/packages/d3fc-annotation/package.json
+++ b/packages/d3fc-annotation/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-annotation"
     },
     "dependencies": {

--- a/packages/d3fc-axis/package.json
+++ b/packages/d3fc-axis/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-axis"
     },
     "dependencies": {

--- a/packages/d3fc-brush/package.json
+++ b/packages/d3fc-brush/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-brush"
   },
   "dependencies": {

--- a/packages/d3fc-chart/package.json
+++ b/packages/d3fc-chart/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-chart",
         "test:types": "tsd"
     },

--- a/packages/d3fc-data-join/package.json
+++ b/packages/d3fc-data-join/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-data-join"
   },
   "peerDependencies": {

--- a/packages/d3fc-discontinuous-scale/package.json
+++ b/packages/d3fc-discontinuous-scale/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-discontinuous-scale"
     },
     "dependencies": {

--- a/packages/d3fc-element/package.json
+++ b/packages/d3fc-element/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-element"
   },
   "publishConfig": {

--- a/packages/d3fc-extent/package.json
+++ b/packages/d3fc-extent/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-extent"
   },
   "peerDependencies": {

--- a/packages/d3fc-financial-feed/package.json
+++ b/packages/d3fc-financial-feed/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-financial-feed"
   },
   "peerDependencies": {

--- a/packages/d3fc-group/package.json
+++ b/packages/d3fc-group/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-group"
   },
   "publishConfig": {

--- a/packages/d3fc-label-layout/package.json
+++ b/packages/d3fc-label-layout/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-label-layout"
     },
     "dependencies": {

--- a/packages/d3fc-pointer/package.json
+++ b/packages/d3fc-pointer/package.json
@@ -5,7 +5,7 @@
     "main": "build/d3fc-pointer.js",
     "module": "index",
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-pointer"
     },
     "repository": {

--- a/packages/d3fc-random-data/package.json
+++ b/packages/d3fc-random-data/package.json
@@ -24,7 +24,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-random-data"
     },
     "dependencies": {

--- a/packages/d3fc-rebind/package.json
+++ b/packages/d3fc-rebind/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-rebind"
   },
   "publishConfig": {

--- a/packages/d3fc-sample/package.json
+++ b/packages/d3fc-sample/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-sample"
     },
     "dependencies": {

--- a/packages/d3fc-series/package.json
+++ b/packages/d3fc-series/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-series"
     },
     "dependencies": {

--- a/packages/d3fc-shape/package.json
+++ b/packages/d3fc-shape/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/d3fc/d3fc"
   },
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-shape"
   },
   "peerDependencies": {

--- a/packages/d3fc-technical-indicator/package.json
+++ b/packages/d3fc-technical-indicator/package.json
@@ -33,7 +33,7 @@
         "url": "https://github.com/d3fc/d3fc"
     },
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-technical-indicator"
     },
     "dependencies": {

--- a/packages/d3fc-webgl/package.json
+++ b/packages/d3fc-webgl/package.json
@@ -15,7 +15,7 @@
   "main": "build/d3fc-webgl.js",
   "module": "index",
   "scripts": {
-    "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+    "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
     "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-webgl"
   },
   "dependencies": {

--- a/packages/d3fc-zoom/package.json
+++ b/packages/d3fc-zoom/package.json
@@ -5,7 +5,7 @@
     "main": "build/d3fc-zoom.js",
     "module": "index",
     "scripts": {
-        "bundle": "npx rollup -c ../../scripts/rollup.config.js",
+        "bundle": "npx rollup -c ../../scripts/rollup.config.mjs",
         "start": "npm start  --prefix ../d3fc -- --configPkg=d3fc-zoom"
     },
     "repository": {

--- a/packages/d3fc/package.json
+++ b/packages/d3fc/package.json
@@ -4,8 +4,8 @@
     "description": "A collection of components that make it easy to build interactive charts with D3",
     "main": "build/d3fc.js",
     "scripts": {
-        "start": "npx rollup -c --environment BUILD:dev --watch",
-        "bundle": "npx rollup -c"
+        "start": "npx rollup -c rollup.config.mjs --environment BUILD:dev --watch",
+        "bundle": "npx rollup -c rollup.config.mjs"
     },
     "repository": {
         "type": "git",

--- a/packages/d3fc/rollup.config.mjs
+++ b/packages/d3fc/rollup.config.mjs
@@ -1,25 +1,28 @@
+import { createRequire } from 'node:module';
 import babel from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
 
+const require = createRequire(import.meta.url);
+
 const devMode = process.env.BUILD === 'dev';
 
 let d3fcPkg = require('./package.json');
 
 /**
- * Provides a method for building d3fc, or for testing code live 
+ * Provides a method for building d3fc, or for testing code live
  * by providing the 'dev' environment variable.
- * 
+ *
  * Command line options for use with 'dev':
- * 
- * --configOpen='foo.html'  
+ *
+ * --configOpen='foo.html'
  *      Starts debugging at /examples/foo.html. If omitted, defaults to index.html
- * 
+ *
  * --configPkg='d3fc-bar'
  *      Starts debugging for the package /packages/d3fc-bar. If omitted defaults to d3fc
- * 
+ *
  * --port=1234
  *      Starts debugging with host on port 1234. If omitted defaults to 8080
  */

--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import babel from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
+
+const require = createRequire(import.meta.url);
 
 var external = key =>
     key.indexOf('d3-') === 0 || key.indexOf('@d3fc/d3fc-') === 0;


### PR DESCRIPTION
## Summary
- Upgrade Rollup from ^2.79.1 (EOL) to ^4.0.0
- Migrate config files from `.js` to `.mjs` to support Rollup 3+'s native Node module loading
- Add `createRequire` from `node:module` to preserve JSON `require()` calls in ESM config context
- Update bundle script paths in all 21 package.json files

No plugin upgrades needed — `@rollup/plugin-babel@6`, `@rollup/plugin-node-resolve@15`, and `@rollup/plugin-terser@0.4` already declare `rollup: ^4.0.0` in their peer dependencies.

No changeset — devDependency upgrade only, no published package changes. Build output (UMD format) is unchanged.

## Migration notes

### Config file rename (`.js` → `.mjs`)

Rollup 2 used its own internal module loader that tolerated mixing `require()` with ESM `import`/`export` in config files. Rollup 3+ delegates to Node's native module loader which does not allow this mix. Renaming to `.mjs` tells Node to treat the file as ESM, and `createRequire(import.meta.url)` provides a `require()` function for loading `package.json` files.

### Files changed

- `scripts/rollup.config.js` → `scripts/rollup.config.mjs` — shared config (used by 20 sub-packages)
- `packages/d3fc/rollup.config.js` → `packages/d3fc/rollup.config.mjs` — umbrella package config
- 21× `packages/*/package.json` — updated bundle script paths to reference `.mjs`
- `package.json` — rollup version bump

## Test plan
- [x] `npm run bundle` — all 21 packages build
- [x] `npm run bundle-min` — all 21 packages minify
- [x] `npm test` — all tests pass
- [x] `npm run lint` — clean