### PR TITLE
feat(examples): add WebGL custom uniform example

### DIFF
--- a/.changeset/add-webgl-uniform-example.md
+++ b/.changeset/add-webgl-uniform-example.md
@@ -1,0 +1,5 @@
+---
+'d3fc': patch
+---
+
+Add WebGL custom uniform example demonstrating shader parameter binding via program.buffers().uniform().

--- a/examples/series-webgl-bar-uniform/README.md
+++ b/examples/series-webgl-bar-uniform/README.md
@@ -1,0 +1,3 @@
+# Series WebGL Bar Uniform
+
+Demonstrates using custom uniforms to pass global parameters to WebGL shaders. Bars are rendered with horizontal stripes where the stripe width is controlled by a `webglUniform`.

--- a/examples/series-webgl-bar-uniform/__tests__/index.js
+++ b/examples/series-webgl-bar-uniform/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/series-webgl-bar-uniform/index.html
+++ b/examples/series-webgl-bar-uniform/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <d3fc-canvas use-device-pixel-ratio set-webgl-viewport></d3fc-canvas>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/series-webgl-bar-uniform/index.js
+++ b/examples/series-webgl-bar-uniform/index.js
@@ -1,0 +1,66 @@
+// Custom uniforms for global shader parameters.
+//
+// Demonstrates:
+// - fc.webglUniform() for global shader values
+// - program.buffers().uniform() for binding uniforms to shaders
+// - Using a uniform to control a visual property (stripe pattern width)
+
+const data = fc.randomGeometricBrownianMotion().steps(200)(1);
+
+const xScale = d3.scaleLinear().domain([0, data.length - 1]);
+
+const yScale = d3.scaleLinear().domain(fc.extentLinear()(data));
+
+const container = document.querySelector('d3fc-canvas');
+
+// Stripe width in pixels — controls the visual density of the pattern
+const stripeWidth = 6.0;
+
+const series = fc
+    .seriesWebglBar()
+    .xScale(xScale)
+    .yScale(yScale)
+    .crossValue((d, i) => i)
+    .mainValue(d => d)
+    .bandwidth(1)
+    .defined(() => true)
+    .equals(previousData => previousData.length > 0)
+    .decorate(program => {
+        // Declare a uniform in the fragment shader for the stripe spacing.
+        program
+            .fragmentShader()
+            .appendHeader('uniform highp float uStripeWidth;')
+            .appendBody(
+                `
+                // Create horizontal stripes using the fragment's y-coordinate.
+                // Alternating bands of the fill color and a darker shade.
+                float stripe = mod(gl_FragCoord.y, uStripeWidth * 2.0);
+                if (stripe < uStripeWidth) {
+                    gl_FragColor = vec4(0.26, 0.53, 0.96, 1.0);
+                } else {
+                    gl_FragColor = vec4(0.18, 0.38, 0.71, 1.0);
+                }
+                `
+            );
+
+        // Create a uniform with a scalar value and bind it to the shader.
+        const stripeWidthUniform = fc.webglUniform().data(stripeWidth);
+
+        program.buffers().uniform('uStripeWidth', stripeWidthUniform);
+    });
+
+let gl = null;
+
+d3.select(container)
+    .on('measure', event => {
+        const { width, height } = event.detail;
+        xScale.range([0, width]);
+        yScale.range([height, 0]);
+        gl = container.querySelector('canvas').getContext('webgl');
+        series.context(gl);
+    })
+    .on('draw', () => {
+        series(data);
+    });
+
+container.requestRedraw();


### PR DESCRIPTION
## Summary
Add `examples/series-webgl-bar-uniform/` — demonstrates using `fc.webglUniform()` to pass global parameters to custom fragment shaders.

Bars are rendered with horizontal stripes where the stripe width is controlled by a uniform. Teaches the uniform binding pattern in isolation.

Motivated by #1894 — user's solution used `fc.webglUniform()` for hatch spacing with no existing example to reference.

**Key APIs demonstrated:**
- `fc.webglUniform().data(value)`
- `program.buffers().uniform('uStripeWidth', uniform)`
- `program.fragmentShader().appendHeader('uniform highp float uStripeWidth;')`

## Test plan
- [x] `npm run lint` — clean
- [x] Visual verification in browser — bars render with horizontal stripe pattern
- [x] Example follows existing pattern
- [x] Changeset included