### PR TITLE
feat(examples): add WebGL conditional fragment shading example

### DIFF
--- a/.changeset/add-webgl-conditional-shader-example.md
+++ b/.changeset/add-webgl-conditional-shader-example.md
@@ -1,0 +1,5 @@
+---
+'d3fc': patch
+---
+
+Add WebGL conditional fragment shading example demonstrating data-driven shader branching for solid vs hatched bar rendering.

--- a/examples/series-webgl-bar-conditional-shader/README.md
+++ b/examples/series-webgl-bar-conditional-shader/README.md
@@ -1,0 +1,3 @@
+# Series WebGL Bar Conditional Shader
+
+Demonstrates conditional fragment shading in WebGL bars based on a per-datapoint state attribute. Every third bar renders with a diagonal hatch pattern, while the rest are solid fill.

--- a/examples/series-webgl-bar-conditional-shader/__tests__/index.js
+++ b/examples/series-webgl-bar-conditional-shader/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/series-webgl-bar-conditional-shader/index.html
+++ b/examples/series-webgl-bar-conditional-shader/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <d3fc-canvas use-device-pixel-ratio set-webgl-viewport></d3fc-canvas>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/series-webgl-bar-conditional-shader/index.js
+++ b/examples/series-webgl-bar-conditional-shader/index.js
@@ -1,0 +1,108 @@
+// Conditional fragment shading based on data state.
+//
+// Demonstrates:
+// - Passing data-driven state flags to shaders via per-datapoint attributes
+// - Conditional logic in fragment shaders (solid vs diagonal hatch)
+// - Combining attributes and uniforms in a single shader
+
+const data = fc.randomGeometricBrownianMotion().steps(200)(1);
+
+// Assign a "confirmed" state to roughly half the bars (alternating)
+const states = data.map((d, i) => (i % 3 === 0 ? 1.0 : 0.0));
+
+// All bars are the same blue — the visual distinction comes from the shader
+const barColor = [0.13, 0.39, 0.76, 1.0];
+const colors = data.map(() => barColor);
+
+const xScale = d3.scaleLinear().domain([0, data.length - 1]);
+
+const yScale = d3.scaleLinear().domain(fc.extentLinear()(data));
+
+const container = document.querySelector('d3fc-canvas');
+
+const hatchSpacing = 8.0;
+
+const series = fc
+    .seriesWebglBar()
+    .xScale(xScale)
+    .yScale(yScale)
+    .crossValue((d, i) => i)
+    .mainValue(d => d)
+    .bandwidth(1)
+    .defined(() => true)
+    .equals(previousData => previousData.length > 0)
+    .decorate(program => {
+        // Vertex shader: forward color and state to fragment shader
+        program
+            .vertexShader()
+            .appendHeader('attribute vec4 aColor;')
+            .appendHeader('attribute float aState;')
+            .appendHeader('varying lowp vec4 vColor;')
+            .appendHeader('varying float vState;')
+            .appendBody(
+                `
+                vColor = aColor;
+                vState = aState;
+                `
+            );
+
+        // Fragment shader: solid fill or diagonal hatch based on state
+        program
+            .fragmentShader()
+            .appendHeader('varying lowp vec4 vColor;')
+            .appendHeader('varying float vState;')
+            .appendHeader('uniform highp float uHatchSpacing;')
+            .appendBody(
+                `
+                if (vState == 1.0) {
+                    // Diagonal hatch: use fragment coordinates to create a stripe pattern
+                    float diagonal = mod(gl_FragCoord.x + gl_FragCoord.y, uHatchSpacing);
+                    float isHatch = step(diagonal, uHatchSpacing * 0.5);
+                    vec4 hatchColor = vec4(0.0, 0.0, 0.0, 0.0);
+                    gl_FragColor = mix(vColor, hatchColor, isHatch);
+                } else {
+                    // Solid fill
+                    gl_FragColor = vColor;
+                }
+                `
+            );
+
+        // Per-datapoint color attribute
+        const colorAttribute = fc
+            .webglAttribute()
+            .size(4)
+            .type(program.context().FLOAT)
+            .data(colors);
+
+        // Per-datapoint state flag (0.0 = solid, 1.0 = hatched)
+        const stateAttribute = fc
+            .webglAttribute()
+            .size(1)
+            .type(program.context().FLOAT)
+            .data(states);
+
+        // Global hatch spacing uniform
+        const hatchSpacingUniform = fc.webglUniform().data(hatchSpacing);
+
+        program
+            .buffers()
+            .attribute('aColor', colorAttribute)
+            .attribute('aState', stateAttribute)
+            .uniform('uHatchSpacing', hatchSpacingUniform);
+    });
+
+let gl = null;
+
+d3.select(container)
+    .on('measure', event => {
+        const { width, height } = event.detail;
+        xScale.range([0, width]);
+        yScale.range([height, 0]);
+        gl = container.querySelector('canvas').getContext('webgl');
+        series.context(gl);
+    })
+    .on('draw', () => {
+        series(data);
+    });
+
+container.requestRedraw();


### PR DESCRIPTION
## Summary
Add `examples/series-webgl-bar-conditional-shader/` — demonstrates conditional logic in fragment shaders driven by a per-datapoint state attribute.

Every third bar renders with a diagonal hatch pattern (state = 1.0), while the rest render as solid fill (state = 0.0). Combines attributes (color + state) and uniforms (hatch spacing) in a single shader.

Motivated by #1894 — user implemented conditional hatching for "Verified" vs normal items.

**Key APIs demonstrated:**
- `fc.webglAttribute().size(1)` for boolean/state flags
- Fragment shader `if (vState == 1.0) { /* hatched */ } else { /* solid */ }`
- Combining `program.buffers().attribute()` and `.uniform()` in one decoration

## Test plan
- [x] `npm run lint` — clean
- [x] Visual verification in browser — solid bars with every third bar hatched
- [x] Example follows existing pattern
- [x] Changeset included