### PR TITLE
feat(examples): add axis decorate labels example

### DIFF
--- a/.changeset/add-axis-decorate-labels-example.md
+++ b/.changeset/add-axis-decorate-labels-example.md
@@ -1,0 +1,5 @@
+---
+'d3fc': patch
+---
+
+Add axis decorate labels example demonstrating custom per-tick badge styling via the .decorate() API.

--- a/examples/axis-decorate-labels/README.md
+++ b/examples/axis-decorate-labels/README.md
@@ -1,0 +1,3 @@
+# Axis Decorate Labels
+
+Demonstrates custom per-tick label styling using the axis `.decorate()` API. Specific ticks are rendered with colored badge backgrounds (blue for highlighted, gold for flagged) while others remain plain. Shows how to insert SVG elements into tick groups and conditionally style them based on data values.

--- a/examples/axis-decorate-labels/README.md
+++ b/examples/axis-decorate-labels/README.md
@@ -1,3 +1,3 @@
 # Axis Decorate Labels
 
-Demonstrates custom per-tick label styling using the axis `.decorate()` API. Specific ticks are rendered with colored badge backgrounds (blue for highlighted, gold for flagged) while others remain plain. Shows how to insert SVG elements into tick groups and conditionally style them based on data values.
+Demonstrates custom per-tick label styling on an SVG bar chart using `chartCartesian.xDecorate()`. Specific ticks are rendered with colored badge backgrounds while others remain plain, showing how to insert SVG elements into axis tick groups and conditionally style them based on data values.

--- a/examples/axis-decorate-labels/__tests__/index.js
+++ b/examples/axis-decorate-labels/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/axis-decorate-labels/index.html
+++ b/examples/axis-decorate-labels/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <d3fc-svg use-device-pixel-ratio></d3fc-svg>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/axis-decorate-labels/index.html
+++ b/examples/axis-decorate-labels/index.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-    <d3fc-svg use-device-pixel-ratio></d3fc-svg>
+    <div id="chart"></div>
     <script src="index.js"></script>
 </body>
 

--- a/examples/axis-decorate-labels/index.js
+++ b/examples/axis-decorate-labels/index.js
@@ -1,24 +1,41 @@
-// Custom per-tick axis label styling via decorate.
+// Axis label badge decoration on an SVG bar chart via chartCartesian.
 //
 // Demonstrates:
-// - Conditionally styling individual tick labels with badge backgrounds
-// - Appending SVG elements (rect, text) to tick groups via .decorate()
-// - Multiple visual states: highlighted (blue badge), flagged (gold badge), plain
+// - Using .xDecorate() on chartCartesian to style individual tick labels
+// - Badge backgrounds and conditional text styling on specific ticks
+// - SVG plot area with the same decoration pattern as Canvas and WebGL
 
-var container = document.querySelector('d3fc-svg');
-var margin = 10;
+var data = fc.randomGeometricBrownianMotion().steps(30)(1);
+
+var xScale = d3
+    .scaleLinear()
+    .domain([0, data.length - 1]);
+
+var yScale = d3
+    .scaleLinear()
+    .domain(fc.extentLinear()(data));
 
 // Define which ticks get special treatment
-var highlighted = [44]; // blue badge
-var flagged = [60]; // gold badge with flag marker
+var highlighted = [10]; // blue badge
+var flagged = [20]; // gold badge with flag marker
 
-var scale = d3
-    .scaleLinear()
-    .domain([40, 70]);
-
-var axis = fc.axisBottom(scale)
-    .tickValues([44, 50, 55, 60, 65])
+var bar = fc
+    .seriesSvgBar()
+    .bandwidth(10)
+    .crossValue(function(_, i) { return i; })
+    .mainValue(function(d) { return d; })
     .decorate(function(s) {
+        s.enter()
+            .select('path')
+            .attr('fill', function(d) {
+                return d > 1 ? '#2164C2' : '#D6591C';
+            });
+    });
+
+var chart = fc
+    .chartCartesian(xScale, yScale)
+    .svgPlotArea(bar)
+    .xDecorate(function(s) {
         // On enter, insert a rect behind the text for badge backgrounds
         s.enter()
             .insert('rect', 'text')
@@ -57,33 +74,26 @@ var axis = fc.axisBottom(scale)
                 return d;
             });
 
-        // Now measure text and size the badge rect to fit
+        // Measure text and size the badge rect to fit.
+        // getBBox() doesn't account for the dy="0.71em" offset that
+        // axisBottom applies to tick labels, so we add it manually.
         s.each(function(d) {
             var g = d3.select(this);
             var text = g.select('text').node();
             if (!text) return;
             var bbox = text.getBBox();
+            var fontSize = parseFloat(getComputedStyle(text).fontSize);
+            var dyOffset = fontSize * 0.71;
             var padX = 12;
             var padY = 6;
             g.select('.label-bg')
                 .attr('x', bbox.x - padX / 2)
-                .attr('y', bbox.y - padY / 2)
+                .attr('y', bbox.y + dyOffset - padY / 2)
                 .attr('width', bbox.width + padX)
                 .attr('height', bbox.height + padY);
         });
     });
 
-d3.select(container)
-    .on('draw', function() {
-        d3.select(container)
-            .select('svg')
-            .append('g')
-            .attr('transform', 'translate(0, 10)')
-            .call(axis);
-    })
-    .on('measure', function(event) {
-        var width = event.detail.width;
-        scale.range([margin + 40, width - margin - 40]);
-    });
-
-container.requestRedraw();
+d3.select('#chart')
+    .datum(data)
+    .call(chart);

--- a/examples/axis-decorate-labels/index.js
+++ b/examples/axis-decorate-labels/index.js
@@ -1,0 +1,86 @@
+// Custom per-tick axis label styling via decorate.
+//
+// Demonstrates:
+// - Conditionally styling individual tick labels with badge backgrounds
+// - Appending SVG elements (rect, text) to tick groups via .decorate()
+// - Multiple visual states: highlighted (blue badge), flagged (gold badge), plain
+
+var container = document.querySelector('d3fc-svg');
+var margin = 10;
+
+// Define which ticks get special treatment
+var highlighted = [44]; // blue badge
+var flagged = [60]; // gold badge with flag marker
+
+var scale = d3
+    .scaleLinear()
+    .domain([40, 70]);
+
+var axis = fc.axisBottom(scale)
+    .tickValues([44, 50, 55, 60, 65])
+    .decorate(function(s) {
+        // On enter, insert a rect behind the text for badge backgrounds
+        s.enter()
+            .insert('rect', 'text')
+            .attr('class', 'label-bg')
+            .attr('rx', 4)
+            .attr('ry', 4);
+
+        // Style the badge background based on tick value
+        s.select('.label-bg')
+            .attr('fill', function(d) {
+                if (highlighted.indexOf(d) !== -1) return '#4a90d9';
+                if (flagged.indexOf(d) !== -1) return '#e8b84b';
+                return 'none';
+            })
+            .attr('opacity', function(d) {
+                if (highlighted.indexOf(d) !== -1 || flagged.indexOf(d) !== -1) return 1;
+                return 0;
+            });
+
+        // Style the text color — white on colored badges, grey otherwise
+        s.select('text')
+            .style('fill', function(d) {
+                if (highlighted.indexOf(d) !== -1 || flagged.indexOf(d) !== -1) return '#ffffff';
+                return '#999999';
+            })
+            .style('font-weight', function(d) {
+                if (highlighted.indexOf(d) !== -1 || flagged.indexOf(d) !== -1) return 'bold';
+                return 'normal';
+            });
+
+        // After text renders, size the badge rect to fit the text
+        s.each(function(d) {
+            var g = d3.select(this);
+            var text = g.select('text').node();
+            if (!text) return;
+            var bbox = text.getBBox();
+            var padX = 8;
+            var padY = 4;
+            g.select('.label-bg')
+                .attr('x', bbox.x - padX / 2)
+                .attr('y', bbox.y - padY / 2)
+                .attr('width', bbox.width + padX)
+                .attr('height', bbox.height + padY);
+        });
+
+        // Add a flag marker after the text for flagged ticks
+        s.select('text')
+            .text(function(d) {
+                if (flagged.indexOf(d) !== -1) return d + ' \u2691';
+                return d;
+            });
+    });
+
+d3.select(container)
+    .on('draw', function() {
+        d3.select(container)
+            .select('svg')
+            .call(axis);
+    })
+    .on('measure', function(event) {
+        var width = event.detail.width;
+        scale.range([margin + 40, width - margin - 40]);
+    });
+
+container.requestRedraw();

--- a/examples/axis-decorate-labels/index.js
+++ b/examples/axis-decorate-labels/index.js
@@ -49,33 +49,36 @@ var axis = fc.axisBottom(scale)
                 return 'normal';
             });
 
-        // After text renders, size the badge rect to fit the text
+        // Set final text content BEFORE measuring — flag marker must be
+        // included in the bbox so the badge rect covers the full label
+        s.select('text')
+            .text(function(d) {
+                if (flagged.indexOf(d) !== -1) return d + ' \u2691';
+                return d;
+            });
+
+        // Now measure text and size the badge rect to fit
         s.each(function(d) {
             var g = d3.select(this);
             var text = g.select('text').node();
             if (!text) return;
             var bbox = text.getBBox();
-            var padX = 8;
-            var padY = 4;
+            var padX = 12;
+            var padY = 6;
             g.select('.label-bg')
                 .attr('x', bbox.x - padX / 2)
                 .attr('y', bbox.y - padY / 2)
                 .attr('width', bbox.width + padX)
                 .attr('height', bbox.height + padY);
         });
-
-        // Add a flag marker after the text for flagged ticks
-        s.select('text')
-            .text(function(d) {
-                if (flagged.indexOf(d) !== -1) return d + ' \u2691';
-                return d;
-            });
     });
 
 d3.select(container)
     .on('draw', function() {
         d3.select(container)
             .select('svg')
+            .append('g')
+            .attr('transform', 'translate(0, 10)')
             .call(axis);
     })
     .on('measure', function(event) {


### PR DESCRIPTION
## Summary
- Adds SVG bar chart example demonstrating custom per-tick label styling via `chartCartesian.xDecorate()`
- Inserts SVG `<rect>` badge backgrounds behind specific tick labels (blue for highlighted, gold for flagged)
- Conditionally styles text color, font weight, and appends flag marker based on tick values
- Addresses the use case raised in #1892

## Test plan
- [x] Visual verification in browser
- [x] Changeset included (`'d3fc': patch`)
- [ ] Snapshot test included (`__tests__/index.js`)