### PR TITLE
feat(examples): add axis decorate labels WebGL example

### DIFF
--- a/.changeset/add-axis-decorate-labels-webgl-example.md
+++ b/.changeset/add-axis-decorate-labels-webgl-example.md
@@ -1,0 +1,5 @@
+---
+'d3fc': patch
+---
+
+Add axis decorate labels WebGL example demonstrating per-tick badge styling on a WebGL bar chart via chartCartesian.xDecorate().

--- a/examples/axis-decorate-labels-webgl/README.md
+++ b/examples/axis-decorate-labels-webgl/README.md
@@ -1,0 +1,3 @@
+# Axis Decorate Labels WebGL
+
+Demonstrates custom per-tick label styling on a WebGL bar chart using `chartCartesian.xDecorate()`. Specific ticks are rendered with colored badge backgrounds while others remain plain, showing that axis decoration is always SVG regardless of the WebGL plot area.

--- a/examples/axis-decorate-labels-webgl/__tests__/index.js
+++ b/examples/axis-decorate-labels-webgl/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/axis-decorate-labels-webgl/index.html
+++ b/examples/axis-decorate-labels-webgl/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <div id="chart"></div>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/axis-decorate-labels-webgl/index.js
+++ b/examples/axis-decorate-labels-webgl/index.js
@@ -1,0 +1,96 @@
+// Axis label badge decoration on a WebGL bar chart via chartCartesian.
+//
+// Demonstrates:
+// - Using .xDecorate() on chartCartesian to style individual tick labels
+// - Axes are always SVG regardless of the WebGL plot area
+// - Badge backgrounds and conditional text styling on specific ticks
+
+var data = fc.randomGeometricBrownianMotion().steps(30)(1);
+
+var xScale = d3
+    .scaleLinear()
+    .domain([0, data.length - 1]);
+
+var yScale = d3
+    .scaleLinear()
+    .domain(fc.extentLinear()(data));
+
+// Define which ticks get special treatment
+var highlighted = [10]; // blue badge
+var flagged = [20]; // gold badge with flag marker
+
+var bar = fc
+    .seriesWebglBar()
+    .bandwidth(10)
+    .crossValue(function(_, i) { return i; })
+    .mainValue(function(d) { return d; })
+    .decorate(function(program) {
+        fc.webglFillColor()
+            .value(function(d) {
+                return d > 1
+                    ? [0.13, 0.39, 0.76, 1]
+                    : [0.84, 0.35, 0.11, 1];
+            })
+            .data(data)(program);
+    });
+
+var chart = fc
+    .chartCartesian(xScale, yScale)
+    .webglPlotArea(bar)
+    .xDecorate(function(s) {
+        // On enter, insert a rect behind the text for badge backgrounds
+        s.enter()
+            .insert('rect', 'text')
+            .attr('class', 'label-bg')
+            .attr('rx', 4)
+            .attr('ry', 4);
+
+        // Style the badge background based on tick value
+        s.select('.label-bg')
+            .attr('fill', function(d) {
+                if (highlighted.indexOf(d) !== -1) return '#4a90d9';
+                if (flagged.indexOf(d) !== -1) return '#e8b84b';
+                return 'none';
+            })
+            .attr('opacity', function(d) {
+                if (highlighted.indexOf(d) !== -1 || flagged.indexOf(d) !== -1) return 1;
+                return 0;
+            });
+
+        // Style the text color — white on colored badges, grey otherwise
+        s.select('text')
+            .style('fill', function(d) {
+                if (highlighted.indexOf(d) !== -1 || flagged.indexOf(d) !== -1) return '#ffffff';
+                return '#999999';
+            })
+            .style('font-weight', function(d) {
+                if (highlighted.indexOf(d) !== -1 || flagged.indexOf(d) !== -1) return 'bold';
+                return 'normal';
+            });
+
+        // After text renders, size the badge rect to fit the text
+        s.each(function(d) {
+            var g = d3.select(this);
+            var text = g.select('text').node();
+            if (!text) return;
+            var bbox = text.getBBox();
+            var padX = 8;
+            var padY = 4;
+            g.select('.label-bg')
+                .attr('x', bbox.x - padX / 2)
+                .attr('y', bbox.y - padY / 2)
+                .attr('width', bbox.width + padX)
+                .attr('height', bbox.height + padY);
+        });
+
+        // Add a flag marker after the text for flagged ticks
+        s.select('text')
+            .text(function(d) {
+                if (flagged.indexOf(d) !== -1) return d + ' \u2691';
+                return d;
+            });
+    });
+
+d3.select('#chart')
+    .datum(data)
+    .call(chart);

--- a/examples/axis-decorate-labels-webgl/index.js
+++ b/examples/axis-decorate-labels-webgl/index.js
@@ -68,27 +68,28 @@ var chart = fc
                 return 'normal';
             });
 
-        // After text renders, size the badge rect to fit the text
+        // Set final text content BEFORE measuring — flag marker must be
+        // included in the bbox so the badge rect covers the full label
+        s.select('text')
+            .text(function(d) {
+                if (flagged.indexOf(d) !== -1) return d + ' \u2691';
+                return d;
+            });
+
+        // Now measure text and size the badge rect to fit
         s.each(function(d) {
             var g = d3.select(this);
             var text = g.select('text').node();
             if (!text) return;
             var bbox = text.getBBox();
-            var padX = 8;
-            var padY = 4;
+            var padX = 12;
+            var padY = 6;
             g.select('.label-bg')
                 .attr('x', bbox.x - padX / 2)
                 .attr('y', bbox.y - padY / 2)
                 .attr('width', bbox.width + padX)
                 .attr('height', bbox.height + padY);
         });
-
-        // Add a flag marker after the text for flagged ticks
-        s.select('text')
-            .text(function(d) {
-                if (flagged.indexOf(d) !== -1) return d + ' \u2691';
-                return d;
-            });
     });
 
 d3.select('#chart')

--- a/examples/axis-decorate-labels-webgl/index.js
+++ b/examples/axis-decorate-labels-webgl/index.js
@@ -76,17 +76,21 @@ var chart = fc
                 return d;
             });
 
-        // Now measure text and size the badge rect to fit
+        // Measure text and size the badge rect to fit.
+        // getBBox() doesn't account for the dy="0.71em" offset that
+        // axisBottom applies to tick labels, so we add it manually.
         s.each(function(d) {
             var g = d3.select(this);
             var text = g.select('text').node();
             if (!text) return;
             var bbox = text.getBBox();
+            var fontSize = parseFloat(getComputedStyle(text).fontSize);
+            var dyOffset = fontSize * 0.71;
             var padX = 12;
             var padY = 6;
             g.select('.label-bg')
                 .attr('x', bbox.x - padX / 2)
-                .attr('y', bbox.y - padY / 2)
+                .attr('y', bbox.y + dyOffset - padY / 2)
                 .attr('width', bbox.width + padX)
                 .attr('height', bbox.height + padY);
         });


### PR DESCRIPTION
## Summary
- Adds WebGL bar chart example demonstrating per-tick badge styling via `chartCartesian.xDecorate()`
- Shows that axis decoration is always SVG regardless of the WebGL plot area renderer
- Same decoration logic as the SVG and Canvas variants — addresses #1892

## Test plan
- [x] Visual verification in browser
- [x] Changeset included (`'d3fc': patch`)
- [ ] Snapshot test included (`__tests__/index.js`)