### PR TITLE
feat(examples): add crosshair band center example

### DIFF
--- a/.changeset/add-crosshair-band-center-example.md
+++ b/.changeset/add-crosshair-band-center-example.md
@@ -1,0 +1,5 @@
+---
+'d3fc': patch
+---
+
+Add crosshair band center example demonstrating how to center a crosshair on scaleBand bar series.

--- a/examples/crosshair-band-center/README.md
+++ b/examples/crosshair-band-center/README.md
@@ -1,0 +1,3 @@
+# Crosshair Band Center
+
+Demonstrates how to center a crosshair on bar series using `d3.scaleBand()`. By default, `scaleBand()` returns the left edge of each band — adding `bandwidth() / 2` to the crosshair's `.x()` accessor centers it on each bar.

--- a/examples/crosshair-band-center/__tests__/index.js
+++ b/examples/crosshair-band-center/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/crosshair-band-center/index.html
+++ b/examples/crosshair-band-center/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <div id="chart"></div>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/crosshair-band-center/index.js
+++ b/examples/crosshair-band-center/index.js
@@ -1,0 +1,108 @@
+// Crosshair centered on band scale bars.
+//
+// d3.scaleBand() returns the left edge of each band, so the crosshair
+// snaps to the left side of bars by default. Adding bandwidth() / 2
+// to the crosshair's .x() accessor centers it on each bar.
+//
+// Demonstrates:
+// - Centering crosshair on scaleBand bars via bandwidth/2 offset
+// - Snapping to nearest bar category (scaleBand has no .invert())
+// - Using fc.pointer() to track mouse position in plot-area coords
+
+var categories = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+var data = categories.map(function(cat) {
+    return { category: cat, value: Math.round(Math.random() * 80 + 20) };
+});
+
+var chartData = {
+    series: data,
+    crosshair: []
+};
+
+var xScale = d3
+    .scaleBand()
+    .domain(categories)
+    .paddingInner(0.2)
+    .paddingOuter(0.1);
+
+var yScale = d3
+    .scaleLinear()
+    .domain([0, d3.max(data, function(d) { return d.value; }) * 1.1]);
+
+var bar = fc
+    .autoBandwidth(fc.seriesSvgBar())
+    .align('left')
+    .crossValue(function(d) { return d.category; })
+    .mainValue(function(d) { return d.value; })
+    .decorate(function(sel) {
+        sel.enter()
+            .select('path')
+            .attr('fill', '#2164C2');
+    });
+
+// scaleBand has no .invert() — find the nearest category from a mouse x position
+function snapToCategory(mouseX) {
+    var domain = xScale.domain();
+    var step = xScale.step();
+    var rangeStart = xScale.range()[0];
+    var index = Math.floor((mouseX - rangeStart) / step);
+    index = Math.max(0, Math.min(domain.length - 1, index));
+    return domain[index];
+}
+
+var crosshair = fc
+    .annotationSvgCrosshair()
+    // X snaps to bar center — category is resolved via snapToCategory(),
+    // then positioned at the band center with bandwidth/2 offset
+    .x(function(d) { return xScale(d.category) + xScale.bandwidth() / 2; })
+    // Y tracks the mouse freely — raw screen coordinate, not snapped to data.
+    // To snap Y to the bar's value instead, use:
+    //   .y(function(d) { return yScale(dataByCategory[d.category]); })
+    .y(function(d) { return d.mouseY; })
+    .xLabel(function(d) { return d.category; })
+    .yLabel(function(d) { return Math.round(yScale.invert(d.mouseY)); })
+    .decorate(function(sel) {
+        sel.selectAll('line').style('stroke-width', '2px');
+    });
+
+var multi = fc
+    .seriesSvgMulti()
+    .series([bar, crosshair])
+    .mapping(function(data, index, series) {
+        switch (series[index]) {
+        case bar: return data.series;
+        case crosshair: return data.crosshair;
+        }
+    });
+
+var pointer = fc.pointer().on('point', function(event) {
+    if (event.length === 0) {
+        chartData.crosshair = [];
+    } else {
+        // X: snap to nearest category (discrete — band scale)
+        // Y: pass raw mouse position (continuous — free tracking)
+        var category = snapToCategory(event[0].x);
+        chartData.crosshair = [{
+            category: category,
+            mouseY: event[0].y
+        }];
+    }
+    render();
+});
+
+var chart = fc
+    .chartCartesian(xScale, yScale)
+    .svgPlotArea(multi)
+    .decorate(function(sel) {
+        sel.enter()
+            .select('.plot-area')
+            .call(pointer);
+    });
+
+function render() {
+    d3.select('#chart')
+        .datum(chartData)
+        .call(chart);
+}
+
+render();


### PR DESCRIPTION
## Summary
- Demonstrates centering a crosshair on `scaleBand` bar series via `bandwidth() / 2`
- X-axis snaps to nearest category, Y-axis tracks mouse freely
- Includes snap-to-category logic since `scaleBand` has no `.invert()`
- Addresses the use case raised in #1764

## Test plan
- [x] Visual verification in browser
- [x] Changeset included (`'d3fc': patch`)
- [ ] Snapshot test included (`__tests__/index.js`)