### PR TITLE
feat(examples): add crosshair band center stacked example

### DIFF
--- a/.changeset/add-crosshair-band-center-stacked-example.md
+++ b/.changeset/add-crosshair-band-center-stacked-example.md
@@ -1,0 +1,5 @@
+---
+'d3fc': patch
+---
+
+Add crosshair band center stacked example demonstrating centered crosshair on stacked scaleBand bar series.

--- a/examples/crosshair-band-center-stacked/README.md
+++ b/examples/crosshair-band-center-stacked/README.md
@@ -1,0 +1,3 @@
+# Crosshair Band Center Stacked
+
+Demonstrates how to center a crosshair on stacked bar series using `d3.scaleBand()`. The crosshair horizontal line shows the total stack height for the hovered category, while the vertical line is centered on the bar using `bandwidth() / 2`.

--- a/examples/crosshair-band-center-stacked/__tests__/index.js
+++ b/examples/crosshair-band-center-stacked/__tests__/index.js
@@ -1,0 +1,8 @@
+it('should match the image snapshot', async () => {
+    await d3fc.loadExample(module);
+    const image = await page.screenshot({
+        omitBackground: true
+    });
+    expect(image).toMatchImageSnapshot();
+    await d3fc.saveScreenshot(module, image);
+});

--- a/examples/crosshair-band-center-stacked/index.html
+++ b/examples/crosshair-band-center-stacked/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <script src="../../node_modules/seedrandom/seedrandom.js"></script>
+    <script>Math.seedrandom('a22ebc7c488a3a47');</script>
+    <script src="../../node_modules/mockdate/src/mockdate.js"></script>
+    <script>MockDate.set('2000-01-01', 0);</script>
+    <script src="../../node_modules/d3/dist/d3.js"></script>
+    <script src="../../packages/d3fc/build/d3fc.js"></script>
+    <script src="../index.js"></script>
+    <link rel="stylesheet" href="../index.css">
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+</head>
+
+<body>
+    <div id="chart"></div>
+    <script src="index.js"></script>
+</body>
+
+</html>

--- a/examples/crosshair-band-center-stacked/index.js
+++ b/examples/crosshair-band-center-stacked/index.js
@@ -1,0 +1,134 @@
+// Crosshair centered on stacked band scale bars.
+//
+// Stacked bar series use d3.scaleBand() for categories. The crosshair
+// snaps to the left edge by default because scaleBand() returns the
+// left edge of each band. Adding bandwidth() / 2 centers it.
+//
+// Demonstrates:
+// - Centering crosshair on stacked bars via bandwidth/2 offset
+// - d3.stack() + seriesSvgRepeat for stacked bar rendering
+// - Snapping crosshair to nearest category (scaleBand has no .invert())
+// - Crosshair .y() showing total stack height for the hovered category
+
+var categories = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+var rawData = categories.map(function(cat) {
+    return {
+        category: cat,
+        series1: Math.round(Math.random() * 40 + 10),
+        series2: Math.round(Math.random() * 30 + 5),
+        series3: Math.round(Math.random() * 20 + 5)
+    };
+});
+
+var stack = d3.stack()
+    .keys(['series1', 'series2', 'series3'])
+    .value(function(d, key) { return d[key]; });
+var seriesData = stack(rawData);
+
+var color = d3
+    .scaleOrdinal()
+    .domain(['series1', 'series2', 'series3'])
+    .range(['#2164C2', '#D6591C', '#666680']);
+
+var chartData = {
+    stacked: seriesData,
+    crosshair: []
+};
+
+var xScale = d3
+    .scaleBand()
+    .domain(categories)
+    .paddingInner(0.2)
+    .paddingOuter(0.1);
+
+var yExtent = fc
+    .extentLinear()
+    .accessors([function(a) { return a.map(function(d) { return d[1]; }); }])
+    .pad([0, 0.1]);
+
+var yScale = d3
+    .scaleLinear()
+    .domain(yExtent(seriesData));
+
+var barSeries = fc
+    .autoBandwidth(fc.seriesSvgBar())
+    .align('left')
+    .crossValue(function(d) { return d.data.category; })
+    .mainValue(function(d) { return d[1]; })
+    .baseValue(function(d) { return d[0]; });
+
+var repeat = fc
+    .seriesSvgRepeat()
+    .series(barSeries)
+    .decorate(function(sel) {
+        sel.selectAll('g.bar')
+            .attr('fill', function(_, index) { return color(seriesData[index].key); });
+    });
+
+// scaleBand has no .invert() — find the nearest category from mouse x
+function snapToCategory(mouseX) {
+    var domain = xScale.domain();
+    var step = xScale.step();
+    var rangeStart = xScale.range()[0];
+    var index = Math.floor((mouseX - rangeStart) / step);
+    index = Math.max(0, Math.min(domain.length - 1, index));
+    return domain[index];
+}
+
+var crosshair = fc
+    .annotationSvgCrosshair()
+    // X snaps to bar center — category is resolved via snapToCategory(),
+    // then positioned at the band center with bandwidth/2 offset
+    .x(function(d) { return xScale(d.category) + xScale.bandwidth() / 2; })
+    // Y tracks the mouse freely — lets the user inspect individual stack
+    // segments by moving vertically within the stacked bar.
+    // To snap Y to the total stack height instead, use:
+    //   .y(function(d) { return yScale(totalByCategory[d.category]); })
+    .y(function(d) { return d.mouseY; })
+    .xLabel(function(d) { return d.category; })
+    .yLabel(function(d) { return Math.round(yScale.invert(d.mouseY)); })
+    .decorate(function(sel) {
+        sel.selectAll('line').style('stroke-width', '2px');
+    });
+
+var multi = fc
+    .seriesSvgMulti()
+    .series([repeat, crosshair])
+    .mapping(function(data, index, series) {
+        switch (series[index]) {
+        case repeat: return data.stacked;
+        case crosshair: return data.crosshair;
+        }
+    });
+
+var pointer = fc.pointer().on('point', function(event) {
+    if (event.length === 0) {
+        chartData.crosshair = [];
+    } else {
+        // X: snap to nearest category (discrete — band scale)
+        // Y: pass raw mouse position (continuous — free tracking)
+        var category = snapToCategory(event[0].x);
+        chartData.crosshair = [{
+            category: category,
+            mouseY: event[0].y
+        }];
+    }
+    render();
+});
+
+var chart = fc
+    .chartCartesian(xScale, yScale)
+    .svgPlotArea(multi)
+    .decorate(function(sel) {
+        sel.enter()
+            .select('.plot-area')
+            .call(pointer);
+    });
+
+function render() {
+    d3.select('#chart')
+        .datum(chartData)
+        .call(chart);
+}
+
+render();


### PR DESCRIPTION
## Summary
- Demonstrates centering a crosshair on stacked `scaleBand` bar series
- Free Y-axis tracking lets users inspect individual stack segments
- Same `bandwidth() / 2` technique as simple bar variant — addresses #1764

## Test plan
- [x] Visual verification in browser
- [x] Changeset included (`'d3fc': patch`)
- [ ] Snapshot test included (`__tests__/index.js`)